### PR TITLE
missing generic implementation in select file

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -276,7 +276,7 @@
 
         if (!existingItemWithFilterValue && !existingSelectionWithFilterValue) {
           _filteredItems = [..._filteredItems, {
-            label: getCreateLabel(filterText),
+            [optionIdentifier]: getCreateLabel(filterText),
             isCreator: true
           }];
         }


### PR DESCRIPTION
I was having issues when I had a custom ```optionIdentifier``` paired with ```isMulti``` & ```isCreatable```. I am using it as a tag input solution in my project and whenever I added a new input it wouldn't show the default create message, it would show undefined. I tracked down the issue to be in the Select file, it wasn't appending the generic optionIdentifier in the ```_filteredItems``` array it was appending specifically ```label```. I changed ```label:``` our for ```optionIdentifier``` and everything started to work.

The library is great since the combination fo svelte and bulma doesn't give us many choices in input fields and yours is very ergonomic.