### PR TITLE
Rearrange `handleClear` logic to dispatch event last

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -441,9 +441,9 @@
   }
 
   export function handleClear() {
-    dispatch('clear', selectedValue);
     selectedValue = undefined;
     listOpen = false;
+    dispatch('clear', selectedValue);
     handleFocus();
   }
 


### PR DESCRIPTION
There is a problem with the `handleClear` function arising because the `clear` event is dispatched at the start of the handler and then `selectedValue` is set to `undefined`.

Suppose I want to attach my own logic to the `clear` event and when the clear button is pressed set the selector to some default value other than `undefined`. If I set up my selector like:
```
<Select {items} bind:selectedValue={myValue} on:clear={() => myValue = {value: 'foo', label: "Default"}} />
```
When the clear button is pressed the `dispatch` will fire (`:444`) and my custom handler will get called. Once my handler is finished then `handleClear` will continue and `selectedValue`, which I just set to my custom default, will overwritten with `undefined` (`:445`).

Rearrange the logic in `handleClear` such that custom logic, if provided, will overwrite the `undefined` value.