### PR TITLE
Remove unused properties from List.svelte to prevent warnings

### DIFF
--- a/src/List.svelte
+++ b/src/List.svelte
@@ -18,16 +18,12 @@
   export let itemHeight = 40;
   export let hoverItemIndex = 0;
   export let selectedValue = undefined;
-  export let start = 0;
-  export let end = 0;
   export let optionIdentifier = 'value';
   export let hideEmptyState = false;
   export let noOptionsMessage = 'No options';
-  export let getOptionString = (option) => option;
   export let isMulti = false;
   export let activeItemIndex = 0;
   export let filterText = '';
-  export let isCreatable = false;
 
   let isScrollingTimer = 0;
   let isScrolling = false;

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -464,7 +464,6 @@
       optionIdentifier,
       noOptionsMessage,
       hideEmptyState,
-      isCreatable,
       isVirtualList,
       selectedValue,
       isMulti,

--- a/test/runner.js
+++ b/test/runner.js
@@ -19,7 +19,11 @@ async function go() {
   page = await browser.newPage();
 
   page.on('console', msg => {
-    console[msg.type()](msg.text());
+    let logType = msg.type();
+    if(logType === 'warning') {
+      logType = 'warn';
+    }
+    console[logType](msg.text());
   });
 
   await page.goto(`http://localhost:${port}`);


### PR DESCRIPTION
As discussed, I removed the unused attributes from List.svelte, and also a line in Select.svelte that was setting `isCreatable` on `List`. Passes tests with no warnings on both the version of Svelte in the lockfile and on the latest 3.15. I did a quick test with my own application that uses this package as well.

I also changed the log handler in the Puppeteer code to use `warn` when the log type is `warning` since it was throwing errors trying to use `console.warning`.

Fixes #94.