### PR TITLE
Add itemFilter prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ yarn add svelte-select
 | isMulti | Boolean | false | Enable multi select
 | isSearchable | Boolean | true | Disable search/filtering
 | isVirtualList | Boolean | false | Uses [svelte-virtual-list](https://github.com/sveltejs/svelte-virtual-list) to render list (experimental)
+| itemFilter | Function | (label, filterText, option) => label.toLowerCase().includes(filterText.toLowerCase()) | Item filter function
 | groupBy | Function | - | Function to group list items
 | groupFilter | Function | (groups) => groups | Group filter function
 | isGroupHeaderSelectable | Boolean | false | Enable selectable group headers

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -21,6 +21,7 @@
   export let filterText = '';
   export let placeholder = 'Select...';
   export let items = [];
+  export let itemFilter = (label, filterText, option) => label.toLowerCase().includes(filterText.toLowerCase());
   export let groupBy = undefined;
   export let groupFilter = (groups) => groups;
   export let isGroupHeaderSelectable = false;
@@ -152,9 +153,9 @@
           });
         }
 
-        if (keepItem && filterText.length < 1) return true;
-
-        return keepItem && getOptionLabel(item, filterText).toLowerCase().includes(filterText.toLowerCase());
+        if (!keepItem) return false;
+        if (filterText.length < 1) return true;
+        return itemFilter(getOptionLabel(item, filterText), filterText, item);
       });
     }
 

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -744,6 +744,23 @@ test('Select filter text filters list', async (t) => {
   select.$destroy();
 });
 
+test('Select filter text filters list with itemFilter', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      items,
+      itemFilter: (label, filterText, option) => label === 'Ice Cream'
+    }
+  });
+
+  await wait(0);
+  t.ok(select.$$.ctx.filteredItems.length === 5);
+  await handleSet(select, {filterText: 'cream ice'})
+  t.ok(select.$$.ctx.filteredItems.length === 1);
+
+  select.$destroy();
+});
+
 test('Typing in the Select filter opens List', async (t) => {
   const select = new Select({
     target,


### PR DESCRIPTION
itemFilter can be used to implement custom searching and filtering logic on local lists.

Example use cases:

* Match words out of order. e.g. If an item has the label "foo bar baz" then filter text "baz foo" should match.
* Match / search metadata in addition to the label text.
* Fuzzy search / autocomplete like modern text editors do. e.g. "cmptr"  would match "computer".

It was almost possible by (ab)using the loadOptions parameter to filter my list. However, when using loadOptions the list is empty until filter text is entered. This is a reasonable assumption when the list a retrieved from a remote source. But in my case the list is local and I need to be able to click on the select and see all the options -- hence this itemFilter prop for local lists.