### PR TITLE
fixed: hideEmptyState state test. '.empty' selector is always null when th…

### DIFF
--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1721,6 +1721,8 @@ test('when hideEmptyState true then do not show "no options" div ', async (t) =>
     }
   });
 
+  await wait(0);
+
   t.ok(!document.querySelector('.empty'));
 
   select.$destroy();


### PR DESCRIPTION
The "no options" element is always null at the beginning so the assertion is always going to be true. Adding an `await` to allow the element to be rendered (in this test it shouldn't render).