### PR TITLE
Removes implicit type conversion

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -160,7 +160,7 @@
             let keepItem = true;
 
             if (isMulti && selectedValue) {
-              keepItem = !selectedValue.find(value => {
+              keepItem = !selectedValue.some(value => {
                 return value[optionIdentifier] === item[optionIdentifier];
               });
             }


### PR DESCRIPTION
[Array.prototype.find() ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) returns the element that matches the function. [Array.prototype.some()]( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) returns true/false if any element matches the functions. 
Relying on the fact that `!undefined === true` doesn't read as nice as simply getting a bool from your function.


