### PR TITLE
Added showIndicator property to force show the chevron indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ yarn add svelte-select
 | hasError | Boolean | false | Show error styles around select input (red border)
 | inputAttributes | Object | - | Pass in attributes like 'id' to the Select input, for example {id: 'Food Selection', foo: 'something'}
 | listAutoWidth | Boolean | true | List width will grow wider than the Select container (depending on list item content length)
+| showIndicator | Boolean | false | If true, the chevron indicator is always shown
 
 ### Styling
 

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -77,6 +77,7 @@
   export let itemHeight = 40;
   export let Icon = undefined;
   export let showChevron = false;
+  export let showIndicator = false;
   export let containerClasses = "";
 
   let target;
@@ -845,7 +846,7 @@
     </div>
   {/if}
 
-  {#if showChevron && !selectedValue || (!isSearchable && !isDisabled && !isWaiting && ((showSelectedItem && !isClearable) || !showSelectedItem))}
+  {#if showIndicator || (showChevron && !selectedValue || (!isSearchable && !isDisabled && !isWaiting && ((showSelectedItem && !isClearable) || !showSelectedItem)))}
     <div class="indicator">
       <svg
         width="100%"

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -2629,12 +2629,42 @@ test('When Icon prop is supplied then render on Select', async (t) => {
   select.$destroy();
 });
 
-test('When showChevron prop is true always show chevron on Select', async (t) => {
+test('When showChevron prop is true only show chevron when there is no selectedValue on Select', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      items,
+      selectedValue: {value: 'chocolate', label: 'Chocolate'},
+      showChevron: true
+    }
+  });
+
+  t.ok(document.querySelectorAll('.indicator').length === 0);
+
+  select.$destroy();
+});
+
+test('When showChevron prop is true and no selectedValue show chevron on Select', async (t) => {
   const select = new Select({
     target,
     props: {
       items,
       showChevron: true
+    }
+  });
+
+  t.ok(document.querySelectorAll('.indicator')[0]);
+
+  select.$destroy();
+});
+
+test('When showIndicator prop is true always show chevron on Select', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      items,
+      selectedValue: {value: 'chocolate', label: 'Chocolate'},
+      showIndicator: true
     }
   });
 


### PR DESCRIPTION
The showIndicator property forces the chevron indicator always to be
shown, even when there is a selected value.