### PR TITLE
Added indicatorSvg for custom indicator styling

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -79,6 +79,7 @@
   export let showChevron = false;
   export let showIndicator = false;
   export let containerClasses = "";
+  export let indicatorSvg = undefined;
 
   let target;
   let activeSelectedValue;
@@ -115,6 +116,8 @@
         [optionIdentifier]: selectedValue,
         label: selectedValue
       };
+    } else if (isMulti && Array.isArray(selectedValue) && selectedValue.length > 0) {
+      selectedValue = selectedValue.map(item => typeof item === "string" ? ({ value: item, label: item }) : item);
     }
   }
 
@@ -595,18 +598,6 @@
     if (items && items.length > 0) {
       originalItemsClone = JSON.stringify(items);
     }
-
-    if (selectedValue) {
-      if (isMulti) {
-        selectedValue = selectedValue.map(item => {
-          if (typeof item === "string") {
-            return { value: item, label: item };
-          } else {
-            return item;
-          }
-        });
-      }
-    }
   });
 
   onDestroy(() => {
@@ -848,19 +839,23 @@
 
   {#if showIndicator || (showChevron && !selectedValue || (!isSearchable && !isDisabled && !isWaiting && ((showSelectedItem && !isClearable) || !showSelectedItem)))}
     <div class="indicator">
-      <svg
-        width="100%"
-        height="100%"
-        viewBox="0 0 20 20"
-        focusable="false"
-        class="css-19bqh2r">
-        <path
-          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747
-          3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0
-          1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502
-          0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0
-          0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z" />
-      </svg>
+      {#if indicatorSvg}
+        {@html indicatorSvg}
+      {:else}
+        <svg
+          width="100%"
+          height="100%"
+          viewBox="0 0 20 20"
+          focusable="false"
+          class="css-19bqh2r">
+          <path
+            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747
+            3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0
+            1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502
+            0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0
+            0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z" />
+        </svg>
+      {/if}
     </div>
   {/if}
 

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1506,6 +1506,24 @@ test('when isMulti, isDisabled, and selectedValue has items then items should be
   select.$destroy();
 });
 
+test('when isMulti is true show each item in selectedValue if simple arrays are used', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      isMulti: true,
+      test: true,
+      items: ['pizza', 'chips', 'chocolate'],
+      selectedValue: ['pizza', 'chocolate']
+    }
+  });
+
+  const all = target.querySelectorAll('.multiSelectItem .multiSelectItem_label');
+  t.ok(all[0].innerHTML === 'pizza');
+  t.ok(all[1].innerHTML === 'chocolate');
+
+  select.$destroy();
+});
+
 test('when getValue method is set should use that key to update selectedValue', async (t) => {
   const select = new Select({
     target,


### PR DESCRIPTION
Extra attribute to override the default SVG used as an indicator. Fill, background, hover etc. can all be easily changed in CSS, the SVG used is more difficult and therefore I have added this as an option for those working with not easily satisfied designer(s).