### PR TITLE
Allow custom Icon component to take props

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -76,6 +76,7 @@
   export let listAutoWidth = true;
   export let itemHeight = 40;
   export let Icon = undefined;
+  export let iconProps = {};
   export let showChevron = false;
   export let showIndicator = false;
   export let containerClasses = "";
@@ -783,7 +784,7 @@
   bind:this={container}>
 
   {#if Icon}
-    <svelte:component this={Icon} />
+    <svelte:component this={Icon} {...iconProps} />
   {/if}
 
   {#if isMulti && selectedValue && selectedValue.length > 0}


### PR DESCRIPTION
New to Svelte so apologies if there's already a way to do this!

I wanted to add individual icons to different Selects on a page, and it looked as though the custom `Icon` component wasn't able to take props (which conflicts with using something like a `FontAwesomeIcon` component, taking FA classes as a prop to determine the icon).

To address that, I introduced the optional `iconProps` parameter to allow passing props into the custom `Icon` component.