### PR TITLE
Prevent multiple updates on focus events

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -347,7 +347,8 @@
         }
       });
 
-      selectedValue = uniqueValues;
+      if (!noDuplicates)
+        selectedValue = uniqueValues;
     }
     return noDuplicates;
   }


### PR DESCRIPTION
Focus events (opening or closing the list with no selection changes) on MultiSelects trigger multiple re-renders when multiple items have been selected. [REPL demo of the issue](https://svelte.dev/repl/182a7be1517b4e52b3c6dad0f706ddad?version=3.24.1).