### PR TITLE
fix input attributes so the defaults can be overwritten

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -142,11 +142,11 @@
 
   let _inputAttributes = {};
   $: {
-    _inputAttributes = Object.assign(inputAttributes, {
+    _inputAttributes = Object.assign({
       autocomplete: "off",
       autocorrect: "off",
       spellcheck: false
-    });
+    }, inputAttributes);
 
     if (!isSearchable) {
       _inputAttributes.readonly = true;

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -2200,11 +2200,17 @@ test('When inputAttributes is supplied each attribute is placed on the Select in
     target,
     props: {
       items,
-      inputAttributes: { id: 'testId' }
+      inputAttributes: {
+        id: 'testId',
+        autocomplete: 'custom-value'
+      }
     }
   });
 
-  t.ok(document.getElementById('testId'));
+  const el = document.getElementById('testId');
+
+  t.equal(el.id, 'testId');
+  t.equal(el.getAttribute('autocomplete'), 'custom-value');
 
   select.$destroy();
 });


### PR DESCRIPTION
Currently, the order of the Object.assign for inputAttributes means that the defaults (ie. autocomplete, autocorrect, and spellcheck) can't be overwritten. This fixes that