### PR TITLE
fix: input overflowing container

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -663,6 +663,7 @@
     line-height: var(--height, 42px);
     padding: var(--inputPadding, var(--padding));
     width: 100%;
+    box-sizing: border-box;
     background: transparent;
     font-size: var(--inputFontSize, 14px);
     letter-spacing: var(--inputLetterSpacing, -0.08px);


### PR DESCRIPTION
Using `width: 100%` + any padding will overflow the container.

My global css does **not** contain the rule:
```css
* {
 box-sizing: border-box;
}
```
![Frame 1](https://user-images.githubusercontent.com/207248/103445429-473c8d00-4c74-11eb-89c0-bd57e061ea58.png)



