### PR TITLE
feat: add more replaceable components

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ yarn add svelte-select
 
 ## API
 
+Properties:
 - `items: Array` Default: `[]`. List of selectable items that appear in the dropdown.
 - `selectedValue: Any` Default: `undefined`. Selected item or items
 - `filterText: String` Default: `''`. Text to filter `items` by.
@@ -66,16 +67,27 @@ yarn add svelte-select
 - `listAutoWidth: Boolean` Default: `true`. List width will grow wider than the Select container (depending on list item content length).
 - `showIndicator: Boolean` Default: `false`. If true, the chevron indicator is always shown.
 - `inputAttributes: Object` Default: `{}`. Useful for passing in HTML attributes like `'id'` to the Select input.
-
-- `Item: Component` Default: `Item`. Item component.
-- `Selection: Component` Default: `Selection`. Selection component.
-- `MultiSelection: Component` Default: `MultiSelection`. Multi selection component.
-- `Icon: Component` Default: `Icon`. Icon component.
-- `iconProps: Object` Default: `{}`. Icon props.
-
+- `positionBuffer: Number` Default: `5`. The distance between select input and the dropdown.
 - `indicatorSvg: @html` Default: `undefined`. Override default SVG chevron indicator.
-
 - `isVirtualList: Boolean` Default: `false`. Uses [svelte-virtual-list](https://github.com/sveltejs/svelte-virtual-list) to render list (experimental).
+
+Replaceable Component Properties:
+- `Clear: Component` Default: `Clear`. The Clear (X) button component.
+- `Container: Component` Default: `Container`. Container for entire select.
+- `Empty: Component` Default: `Empty`. Empty component which displays when the dropdown is empty.
+- `GroupItem: Component` Default: `GroupItem`. The component which displays item groups.
+- `Icon: Component` Default: `Icon`. Icon component.
+  - `iconProps: Object` Default: `{}`. Icon props to send to Icon component.
+- `Indicator: Component` Default: `Indicator`. The indicator/chevron component.
+- `Input: Component` Default: `Input`. The component for text input.
+- `Item: Component` Default: `Item`. Item component for each item in the dropdown.
+- `ItemContainer: Component` Default: `ItemContainer`. Item container component which wraps each item.
+- `ListContainer: Component` Default: `ListContainer`. List container component which wraps the list in the dropdown.
+- `MultiSelection: Component` Default: `MultiSelection`. Multi selection component.
+- `Selection: Component` Default: `Selection`. Selection component which shows the selected value(s).
+- `SelectionContainer: Component` Default: `SelectionContainer`. Selection container component which wraps the selection component.
+- `Spinner: Component` Default: `Spinner`. The spinner component displayed when items are loading.
+
 
 ### Exposed methods
 If you really want to get your hands dirty these internal functions are exposed as props to override if needed. See the adv demo or look through the test file (test/src/index.js) for examples.
@@ -234,13 +246,15 @@ test.only('when getSelectionLabel contains HTML then render the HTML', async (t)
 
 ```
 
+## Using with Bootstrap or other CSS framework
+
+See the [examples here](examples/bootstrap).
 
 ## Configuring webpack
 
 If you're using webpack with [svelte-loader](https://github.com/sveltejs/svelte-loader), make sure that you add `"svelte"` to [`resolve.mainFields`](https://webpack.js.org/configuration/resolve/#resolve-mainfields) in your webpack config. This ensures that webpack imports the uncompiled component (`src/index.html`) rather than the compiled version (`index.mjs`) — this is more efficient.
 
 If you're using Rollup with [rollup-plugin-svelte](https://github.com/rollup/rollup-plugin-svelte), this will happen automatically.
-
 
 ## License
 

--- a/examples/bootstrap/CSS-Variables/App.svelte
+++ b/examples/bootstrap/CSS-Variables/App.svelte
@@ -1,0 +1,63 @@
+<script>
+  import SvelteSelect from '../../../src/Select.svelte';
+
+  let selectedValue = null;
+
+  const optionIdentifier = 'id';
+  const getSelectionLabel = item => item.name;
+
+  // apply the Bootstrap class to svelte-select's internal input
+  const inputAttributes = {
+    class: 'form-control'
+  };
+
+  const items = [
+    {id: 1, name: 'First'},
+    {id: 2, name: 'Second'},
+    {id: 3, name: 'Third'}
+  ];
+
+</script>
+
+<div class="form-group">
+  <SvelteSelect
+    {getSelectionLabel}
+    {inputAttributes}
+    {items}
+    {optionIdentifier}
+    bind:selectedValue
+    placeholder="Search Objects..."/>
+</div>
+
+<!--
+  Bootstrap < 5.0
+    Options:
+      1. (This method) Use Sass and map bootstrap variables to the
+         CSS Variables used by svelte-slect
+      2. Use custom components to make more use of Bootstrap classes
+         within svelte-select (works with Sass or bootstrap.min.css)
+      3. Duplicate the values of the Bootstrap variables for your theme
+         for the items you need to map to CSS Variables in svelte-select
+         (not recommended; works with bootstrap.min.css)
+
+  Bootstrap >= 5.0
+    Options:
+      1. (Similar to this method) Map Bootstrap's CSS Variables to those
+      used by svelte-select (works with Sass or bootstrap.min.css)
+        e.g.: --background: var(--input-bg)
+      2. Use custom components to make more use of Bootstrap classes
+         within svelte-select (works with Sass or bootstrap.min.css)
+-->
+<style lang="scss" global>
+  /* if you are using a bootswatch-esque theme, import the variables here */
+  @import "bootstrap/scss/bootstrap.scss";
+  /* if bootswatch, import the bootswatch.scss */
+
+  .selectContainer {
+    --background: #{$input-bg};
+    --border: 1px solid #{$border-color};
+    --placeholderColor: #{$input-placeholder-color};
+    /* etc... */
+  }
+</style>
+

--- a/examples/bootstrap/Custom-Components/App.svelte
+++ b/examples/bootstrap/Custom-Components/App.svelte
@@ -1,0 +1,43 @@
+<script>
+  import SvelteSelect from '../../../src/Select.svelte';
+
+  import Container from './Container.svelte';
+  import Empty from './Empty.svelte';
+  import Item from './Item.svelte';
+  import ItemContainer from './ItemContainer.svelte';
+  import ListContainer from './ListContainer.svelte';
+  import SelectionContainer from './SelectionContainer.svelte';
+  // You can also override the GroupItem component if necessary
+
+  export let selectedValue = null;
+
+  const optionIdentifier = 'id';
+  const getSelectionLabel = item => item.name;
+
+  // apply the Bootstrap class to svelte-select's internal input
+  const inputAttributes = {
+    class: 'form-control'
+  };
+
+  const items = [
+    {id: 1, name: 'First'},
+    {id: 2, name: 'Second'},
+    {id: 3, name: 'Third'}
+  ];
+</script>
+
+<div class="form-group">
+  <SvelteSelect
+    {Container}
+    {Empty}
+    {Item}
+    {ItemContainer}
+    {ListContainer}
+    {SelectionContainer}
+    {getSelectionLabel}
+    {inputAttributes}
+    {items}
+    {optionIdentifier}
+    bind:selectedValue
+    placeholder="Search Objects..."/>
+</div>

--- a/examples/bootstrap/Custom-Components/Container.svelte
+++ b/examples/bootstrap/Custom-Components/Container.svelte
@@ -1,0 +1,24 @@
+<script>
+  export let hasError = false;
+  export let instance;
+
+  // our minimal example just uses the above; you could also integrate these
+  /* export let isDisabled = false; */
+  /* export let isFocused = false; */
+</script>
+
+<style>
+  .selectContainer {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+</style>
+
+<div class="selectContainer"
+  class:hasError
+  class:border-danger={hasError}
+  on:click
+  bind:this={instance}>
+  <slot/>
+</div>

--- a/examples/bootstrap/Custom-Components/Empty.svelte
+++ b/examples/bootstrap/Custom-Components/Empty.svelte
@@ -1,0 +1,3 @@
+<div class="list-group-item">
+  <slot/>
+</div>

--- a/examples/bootstrap/Custom-Components/Item.svelte
+++ b/examples/bootstrap/Custom-Components/Item.svelte
@@ -1,0 +1,25 @@
+<script>
+  export let isActive = false;
+  export let item;
+
+  let el;
+  $: parent = el ? el.parentElement : null;
+
+  // Bootstrap wants all of these on the same element, and binding a variable from slotted
+  // content to the parent is either impossible or just obtuse, so we'll do this in a fairly
+  // straightforward JS way.
+  $: {
+    if (parent) {
+      if (isActive && !parent.classList.contains('active')) {
+        parent.classList.add('active');
+      } else if (!isActive && parent.classList.contains('active')) {
+        parent.classList.remove('active');
+      }
+    }
+  }
+</script>
+
+<div bind:this={el}>
+  {item.name}
+  <small>Community: {item.coi} Last Modified: {item.lastModified}</small>
+</div>

--- a/examples/bootstrap/Custom-Components/ItemContainer.svelte
+++ b/examples/bootstrap/Custom-Components/ItemContainer.svelte
@@ -1,0 +1,13 @@
+<!--
+  Bootstrap likes it when these classes don't have wrappers in the list, so
+  <div on:click on:mouseover><slot/></div> is no good. If anyone knows of a
+  way to pass through on:click and on:mouseover to Item.svelte, that would
+  simplify things as this could be just <slot/> and all the markup could be
+  there.
+-->
+<div
+  class="list-group-item list-group-item-action"
+  on:click
+  on:mouseover>
+  <slot/>
+</div>

--- a/examples/bootstrap/Custom-Components/ListContainer.svelte
+++ b/examples/bootstrap/Custom-Components/ListContainer.svelte
@@ -1,0 +1,10 @@
+<script>
+  // the full default implementation is in src/ListContainer.svelte
+
+  // minimally, we must provide a reference to the container back to the parent
+  export let instance;
+</script>
+
+<div class="list-group shadow" bind:this={instance}>
+  <slot/>
+</div>

--- a/examples/bootstrap/Custom-Components/SelectionContainer.svelte
+++ b/examples/bootstrap/Custom-Components/SelectionContainer.svelte
@@ -1,0 +1,26 @@
+<script>
+  import {onMount} from 'svelte';
+
+  let container;
+
+  onMount(() => {
+    // This is a touch weird. We want the spacing to match
+    // .form-control, but without requiring bootstrap via sass
+    // for the $input-padding-x/y variables.
+    const input = document.querySelector('.selectContainer input');
+    const style = window.getComputedStyle(input);
+    container.style.padding = style.padding;
+    container.style.margin = style.margin;
+  });
+</script>
+
+<style>
+  .selectionContainer {
+    pointer-events: none;
+    position: absolute;
+  }
+</style>
+
+<div class="selectionContainer" on:focus bind:this={container}>
+  <slot/>
+</div>

--- a/src/Clear.svelte
+++ b/src/Clear.svelte
@@ -1,0 +1,30 @@
+<style>
+  .clearSelect {
+    position: absolute;
+    right: var(--clearSelectRight, 10px);
+    top: var(--clearSelectTop, 11px);
+    bottom: var(--clearSelectBottom, 11px);
+    width: var(--clearSelectWidth, 20px);
+    color: var(--clearSelectColor, #c5cacf);
+    flex: none !important;
+  }
+
+  .clearSelect:hover {
+    color: var(--clearSelectHoverColor, #2c3e50);
+  }
+</style>
+
+<div class="clearSelect" on:click|preventDefault>
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="-2 -2 50 50"
+    focusable="false"
+    role="presentation">
+    <path
+      fill="currentColor"
+      d="M34.923,37.251L24,26.328L13.077,37.251L9.436,33.61l10.923-10.923L9.436,11.765l3.641-3.641L24,19.047L34.923,8.124
+      l3.641,3.641L27.641,22.688L38.564,33.61L34.923,37.251z" />
+  </svg>
+</div>
+

--- a/src/Container.svelte
+++ b/src/Container.svelte
@@ -1,0 +1,105 @@
+<script>
+  export let containerClasses = '';
+  export let containerStyles = '';
+  export let hasError = false;
+  export let instance;
+  export let isDisabled = false;
+  export let isFocused = false;
+  export let isMulti = false;
+</script>
+
+<style>
+  .selectContainer {
+    --padding: 0 16px;
+
+    border: var(--border, 1px solid #d8dbdf);
+    border-radius: var(--borderRadius, 3px);
+    height: var(--height, 42px);
+    position: relative;
+    display: flex;
+    align-items: center;
+    padding: var(--padding);
+    background: var(--background, #fff);
+  }
+
+  .selectContainer :global(input) {
+    cursor: default;
+    border: none;
+    color: var(--inputColor, #3f4f5f);
+    height: var(--height, 42px);
+    line-height: var(--height, 42px);
+    padding: var(--inputPadding, var(--padding));
+    width: 100%;
+    background: transparent;
+    font-size: var(--inputFontSize, 14px);
+    letter-spacing: var(--inputLetterSpacing, -0.08px);
+    position: absolute;
+    left: var(--inputLeft, 0);
+  }
+
+  .selectContainer :global(input::placeholder) {
+    color: var(--placeholderColor, #78848f);
+    opacity: var(--placeholderOpacity, 1);
+  }
+
+  .selectContainer :global(input:focus) {
+    outline: none;
+  }
+
+  .selectContainer:hover {
+    border-color: var(--borderHoverColor, #b2b8bf);
+  }
+
+  .selectContainer.focused {
+    border-color: var(--borderFocusColor, #006fe8);
+  }
+
+  .selectContainer.disabled {
+    background: var(--disabledBackground, #ebedef);
+    border-color: var(--disabledBorderColor, #ebedef);
+    color: var(--disabledColor, #c1c6cc);
+  }
+
+  .selectContainer.disabled :global(input::placeholder) {
+    color: var(--disabledPlaceholderColor, #c1c6cc);
+    opacity: var(--disabledPlaceholderOpacity, 1);
+  }
+
+  .selectContainer.multiSelect :global(input) {
+    padding: var(--multiSelectInputPadding, 0);
+    position: relative;
+    margin: var(--multiSelectInputMargin, 0);
+  }
+
+  .selectContainer.focused :global(.clearSelect) {
+    color: var(--clearSelectFocusColor, #3f4f5f);
+  }
+
+  .hasError {
+    border: var(--errorBorder, 1px solid #ff2d55);
+    background: var(--errorBackground, #fff);
+  }
+
+  .multiSelect {
+    display: flex;
+    padding: var(--multiSelectPadding, 0 35px 0 16px);
+    height: auto;
+    flex-wrap: wrap;
+    align-items: stretch;
+  }
+
+  .multiSelect > * {
+    flex: 1 1 50px;
+  }
+</style>
+
+<div class="selectContainer {containerClasses}"
+  class:hasError
+  class:multiSelect={isMulti}
+  class:disabled={isDisabled}
+  class:focused={isFocused}
+  style={containerStyles}
+  on:click
+  bind:this={instance}>
+  <slot/>
+</div>

--- a/src/Empty.svelte
+++ b/src/Empty.svelte
@@ -1,0 +1,11 @@
+<style>
+  .empty {
+    text-align: var(--listEmptyTextAlign, center);
+    padding: var(--listEmptyPadding, 20px 0);
+    color: var(--listEmptyColor, #78848F);
+  }
+</style>
+
+<div class="empty">
+  <slot/>
+</div>

--- a/src/GroupItem.svelte
+++ b/src/GroupItem.svelte
@@ -1,0 +1,6 @@
+<script>
+  export let getGroupHeaderLabel;
+  export let item;
+</script>
+
+<div class="listGroupTitle">{getGroupHeaderLabel(item)}</div>

--- a/src/Indicator.svelte
+++ b/src/Indicator.svelte
@@ -1,0 +1,41 @@
+<script>
+  export let indicatorSvg = undefined;
+</script>
+
+<style>
+  .indicator {
+    position: absolute;
+    right: var(--indicatorRight, 10px);
+    top: var(--indicatorTop, 11px);
+    width: var(--indicatorWidth, 20px);
+    height: var(--indicatorHeight, 20px);
+    color: var(--indicatorColor, #c5cacf);
+  }
+
+  .indicator svg {
+    display: inline-block;
+    fill: var(--indicatorFill, currentcolor);
+    line-height: 1;
+    stroke: var(--indicatorStroke, currentcolor);
+    stroke-width: 0;
+  }
+</style>
+
+<div class="indicator">
+  {#if indicatorSvg}
+    {@html indicatorSvg}
+  {:else}
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 20 20"
+      focusable="false">
+      <path
+        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747
+        3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0
+        1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502
+        0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0
+        0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z" />
+    </svg>
+  {/if}
+</div>

--- a/src/Input.svelte
+++ b/src/Input.svelte
@@ -1,0 +1,27 @@
+<script>
+  export let inputAttributes = {};
+  export let inputStyles = '';
+  export let instance;
+  export let isDisabled = false;
+  export let placeholderText = '';
+  export let value = '';
+</script>
+
+{#if isDisabled}
+  <input
+    {...inputAttributes}
+    bind:this={instance}
+    on:focus
+    bind:value
+    placeholder={placeholderText}
+    style={inputStyles}
+    disabled />
+{:else}
+  <input
+    {...inputAttributes}
+    bind:this={instance}
+    on:focus
+    bind:value
+    placeholder={placeholderText}
+    style={inputStyles}/>
+{/if}

--- a/src/Item.svelte
+++ b/src/Item.svelte
@@ -57,8 +57,6 @@
   }
 </style>
 
-
-
 <div class="item {itemClasses}">
   {@html getOptionLabel(item, filterText)}
 </div>

--- a/src/ItemContainer.svelte
+++ b/src/ItemContainer.svelte
@@ -1,0 +1,3 @@
+<div class="listItem" on:mouseover on:click>
+  <slot/>
+</div>

--- a/src/ListContainer.svelte
+++ b/src/ListContainer.svelte
@@ -1,0 +1,24 @@
+<script>
+  export let instance;
+  export let isVirtual = false;
+</script>
+
+<style>
+  .listContainer {
+    box-shadow: var(--listShadow, 0 2px 3px 0 rgba(44, 62, 80, 0.24));
+    border-radius: var(--listBorderRadius, 4px);
+    max-height: var(--listMaxHeight, 250px);
+    overflow-y: auto;
+    background: var(--listBackground, #fff);
+  }
+
+  .virtualList {
+    height: var(--virtualListHeight, 200px);
+  }
+</style>
+
+<div class="listContainer"
+  class:virtualList={isVirtual}
+  bind:this={instance}>
+  <slot/>
+</div>

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -6,19 +6,35 @@
     onMount,
     tick
   } from "svelte";
-  import List from "./List.svelte";
+  import ClearComponent from "./Clear.svelte";
+  import ContainerComponent from "./Container.svelte";
+  import IndicatorComponent from "./Indicator.svelte";
+  import InputComponent from "./Input.svelte";
   import ItemComponent from "./Item.svelte";
-  import SelectionComponent from "./Selection.svelte";
+  import List from "./List.svelte";
   import MultiSelectionComponent from "./MultiSelection.svelte";
+  import SelectionComponent from "./Selection.svelte";
+  import SelectionContainerComponent from "./SelectionContainer.svelte";
+  import SpinnerComponent from "./Spinner.svelte";
   import isOutOfViewport from "./utils/isOutOfViewport";
   import debounce from "./utils/debounce";
 
   const dispatch = createEventDispatcher();
   export let container = undefined;
   export let input = undefined;
+  export let Clear = ClearComponent;
+  export let Container = ContainerComponent;
+  export let Empty = undefined;
+  export let GroupItem = undefined;
+  export let Indicator = IndicatorComponent;
+  export let Input = InputComponent;
   export let Item = ItemComponent;
-  export let Selection = SelectionComponent;
+  export let ItemContainer = undefined;
+  export let ListContainer = undefined;
   export let MultiSelection = MultiSelectionComponent;
+  export let Selection = SelectionComponent;
+  export let SelectionContainer = SelectionContainerComponent;
+  export let Spinner = SpinnerComponent;
   export let isMulti = false;
   export let multiFullItemClearable = false;
   export let isDisabled = false;
@@ -27,6 +43,7 @@
   export let selectedValue = undefined;
   export let filterText = "";
   export let placeholder = "Select...";
+  export let positionBuffer = 5;
   export let items = [];
   export let itemFilter = (label, filterText, option) =>
     label.toLowerCase().includes(filterText.toLowerCase());
@@ -369,7 +386,7 @@
   function findItem(selection) {
     let matchTo = selection ? selection[optionIdentifier] : selectedValue[optionIdentifier];
     return items.find(item => item[optionIdentifier] === matchTo);
-  } 
+  }
 
   function updateSelectedValueDisplay(items) {
     if (!items || items.length === 0 || items.some(item => typeof item !== "object")) return;
@@ -417,9 +434,9 @@
     target.style.left = "0";
 
     if (listPlacement === "top") {
-      target.style.bottom = `${height + 5}px`;
+      target.style.bottom = `${height + positionBuffer}px`;
     } else {
-      target.style.top = `${height + 5}px`;
+      target.style.top = `${height + positionBuffer}px`;
     }
 
     target = target;
@@ -545,7 +562,11 @@
     if (target && list) return;
 
     const data = {
+      Empty,
+      GroupItem,
       Item,
+      ItemContainer,
+      ListContainer,
       filterText,
       optionIdentifier,
       noOptionsMessage,
@@ -641,182 +662,22 @@
   });
 </script>
 
-<style>
-  .selectContainer {
-    --padding: 0 16px;
-
-    border: var(--border, 1px solid #d8dbdf);
-    border-radius: var(--borderRadius, 3px);
-    height: var(--height, 42px);
-    position: relative;
-    display: flex;
-    align-items: center;
-    padding: var(--padding);
-    background: var(--background, #fff);
-  }
-
-  .selectContainer input {
-    cursor: default;
-    border: none;
-    color: var(--inputColor, #3f4f5f);
-    height: var(--height, 42px);
-    line-height: var(--height, 42px);
-    padding: var(--inputPadding, var(--padding));
-    width: 100%;
-    background: transparent;
-    font-size: var(--inputFontSize, 14px);
-    letter-spacing: var(--inputLetterSpacing, -0.08px);
-    position: absolute;
-    left: var(--inputLeft, 0);
-  }
-
-  .selectContainer input::placeholder {
-    color: var(--placeholderColor, #78848f);
-    opacity: var(--placeholderOpacity, 1);
-  }
-
-  .selectContainer input:focus {
-    outline: none;
-  }
-
-  .selectContainer:hover {
-    border-color: var(--borderHoverColor, #b2b8bf);
-  }
-
-  .selectContainer.focused {
-    border-color: var(--borderFocusColor, #006fe8);
-  }
-
-  .selectContainer.disabled {
-    background: var(--disabledBackground, #ebedef);
-    border-color: var(--disabledBorderColor, #ebedef);
-    color: var(--disabledColor, #c1c6cc);
-  }
-
-  .selectContainer.disabled input::placeholder {
-    color: var(--disabledPlaceholderColor, #c1c6cc);
-    opacity: var(--disabledPlaceholderOpacity, 1);
-  }
-
-  .selectedItem {
-    line-height: var(--height, 42px);
-    height: var(--height, 42px);
-    overflow-x: hidden;
-    padding: var(--selectedItemPadding, 0 20px 0 0);
-  }
-
-  .selectedItem:focus {
-    outline: none;
-  }
-
-  .clearSelect {
-    position: absolute;
-    right: var(--clearSelectRight, 10px);
-    top: var(--clearSelectTop, 11px);
-    bottom: var(--clearSelectBottom, 11px);
-    width: var(--clearSelectWidth, 20px);
-    color: var(--clearSelectColor, #c5cacf);
-    flex: none !important;
-  }
-
-  .clearSelect:hover {
-    color: var(--clearSelectHoverColor, #2c3e50);
-  }
-
-  .selectContainer.focused .clearSelect {
-    color: var(--clearSelectFocusColor, #3f4f5f);
-  }
-
-  .indicator {
-    position: absolute;
-    right: var(--indicatorRight, 10px);
-    top: var(--indicatorTop, 11px);
-    width: var(--indicatorWidth, 20px);
-    height: var(--indicatorHeight, 20px);
-    color: var(--indicatorColor, #c5cacf);
-  }
-
-  .indicator svg {
-    display: inline-block;
-    fill: var(--indicatorFill, currentcolor);
-    line-height: 1;
-    stroke: var(--indicatorStroke, currentcolor);
-    stroke-width: 0;
-  }
-
-  .spinner {
-    position: absolute;
-    right: var(--spinnerRight, 10px);
-    top: var(--spinnerLeft, 11px);
-    width: var(--spinnerWidth, 20px);
-    height: var(--spinnerHeight, 20px);
-    color: var(--spinnerColor, #51ce6c);
-    animation: rotate 0.75s linear infinite;
-  }
-
-  .spinner_icon {
-    display: block;
-    height: 100%;
-    transform-origin: center center;
-    width: 100%;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    margin: auto;
-    -webkit-transform: none;
-  }
-
-  .spinner_path {
-    stroke-dasharray: 90;
-    stroke-linecap: round;
-  }
-
-  .multiSelect {
-    display: flex;
-    padding: var(--multiSelectPadding, 0 35px 0 16px);
-    height: auto;
-    flex-wrap: wrap;
-    align-items: stretch;
-  }
-
-  .multiSelect > * {
-    flex: 1 1 50px;
-  }
-
-  .selectContainer.multiSelect input {
-    padding: var(--multiSelectInputPadding, 0);
-    position: relative;
-    margin: var(--multiSelectInputMargin, 0);
-  }
-
-  .hasError {
-    border: var(--errorBorder, 1px solid #ff2d55);
-    background: var(--errorBackground, #fff);
-  }
-
-  @keyframes rotate {
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-</style>
 
 <svelte:window
   on:click={handleWindowClick}
   on:keydown={handleKeyDown}
   on:resize={getPosition} />
 
-<div
-  class="selectContainer {containerClasses}"
-  class:hasError
-  class:multiSelect={isMulti}
-  class:disabled={isDisabled}
-  class:focused={isFocused}
-  style={containerStyles}
+<svelte:component
+  this={Container}
+  {containerClasses}
+  {containerStyles}
+  {hasError}
+  {isMulti}
+  {isDisabled}
+  {isFocused}
   on:click={handleClick}
-  bind:this={container}>
+  bind:instance={container}>
 
   {#if Icon}
     <svelte:component this={Icon} {...iconProps} />
@@ -834,84 +695,34 @@
       on:focus={handleFocus} />
   {/if}
 
-  {#if isDisabled}
-    <input
-      {..._inputAttributes}
-      bind:this={input}
-      on:focus={handleFocus}
-      bind:value={filterText}
-      placeholder={placeholderText}
-      style={inputStyles}
-      disabled />
-  {:else}
-    <input
-      {..._inputAttributes}
-      bind:this={input}
-      on:focus={handleFocus}
-      bind:value={filterText}
-      placeholder={placeholderText}
-      style={inputStyles} />
-  {/if}
+  <svelte:component
+    this={Input}
+    inputAttributes={_inputAttributes}
+    {isDisabled}
+    {inputStyles}
+    {placeholderText}
+    on:focus={handleFocus}
+    bind:value={filterText}
+    bind:instance={input}/>
 
   {#if !isMulti && showSelectedItem}
-    <div class="selectedItem" on:focus={handleFocus}>
+    <svelte:component this={SelectionContainer} on:focus={handleFocus}>
       <svelte:component
         this={Selection}
         item={selectedValue}
         {getSelectionLabel} />
-    </div>
+    </svelte:component>
   {/if}
 
   {#if showSelectedItem && isClearable && !isDisabled && !isWaiting}
-    <div class="clearSelect" on:click|preventDefault={handleClear}>
-      <svg
-        width="100%"
-        height="100%"
-        viewBox="-2 -2 50 50"
-        focusable="false"
-        role="presentation">
-        <path
-          fill="currentColor"
-          d="M34.923,37.251L24,26.328L13.077,37.251L9.436,33.61l10.923-10.923L9.436,11.765l3.641-3.641L24,19.047L34.923,8.124
-          l3.641,3.641L27.641,22.688L38.564,33.61L34.923,37.251z" />
-      </svg>
-    </div>
+    <svelte:component this={Clear} on:click={handleClear}/>
   {/if}
 
   {#if showIndicator || (showChevron && !selectedValue || (!isSearchable && !isDisabled && !isWaiting && ((showSelectedItem && !isClearable) || !showSelectedItem)))}
-    <div class="indicator">
-      {#if indicatorSvg}
-        {@html indicatorSvg}
-      {:else}
-        <svg
-          width="100%"
-          height="100%"
-          viewBox="0 0 20 20"
-          focusable="false">
-          <path
-            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747
-            3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0
-            1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502
-            0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0
-            0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z" />
-        </svg>
-      {/if}
-    </div>
+    <svelte:component this={Indicator} {indicatorSvg}/>
   {/if}
 
   {#if isWaiting}
-    <div class="spinner">
-      <svg class="spinner_icon" viewBox="25 25 50 50">
-        <circle
-          class="spinner_path"
-          cx="50"
-          cy="50"
-          r="20"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="5"
-          stroke-miterlimit="10" />
-      </svg>
-    </div>
+    <svelte:component this={Spinner}/>
   {/if}
-</div>
+</svelte:component>

--- a/src/SelectionContainer.svelte
+++ b/src/SelectionContainer.svelte
@@ -1,0 +1,16 @@
+<style>
+  .selectedItem {
+    line-height: var(--height, 42px);
+    height: var(--height, 42px);
+    overflow-x: hidden;
+    padding: var(--selectedItemPadding, 0 20px 0 0);
+  }
+
+  .selectedItem:focus {
+    outline: none;
+  }
+</style>
+
+<div class="selectedItem" on:focus>
+  <slot/>
+</div>

--- a/src/Spinner.svelte
+++ b/src/Spinner.svelte
@@ -1,0 +1,51 @@
+<style>
+  .spinner {
+    position: absolute;
+    right: var(--spinnerRight, 10px);
+    top: var(--spinnerLeft, 11px);
+    width: var(--spinnerWidth, 20px);
+    height: var(--spinnerHeight, 20px);
+    color: var(--spinnerColor, #51ce6c);
+    animation: rotate 0.75s linear infinite;
+  }
+
+  .spinner_icon {
+    display: block;
+    height: 100%;
+    transform-origin: center center;
+    width: 100%;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    -webkit-transform: none;
+  }
+
+  .spinner_path {
+    stroke-dasharray: 90;
+    stroke-linecap: round;
+  }
+
+  @keyframes rotate {
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+</style>
+
+<div class="spinner">
+  <svg class="spinner_icon" viewBox="25 25 50 50">
+    <circle
+      class="spinner_path"
+      cx="50"
+      cy="50"
+      r="20"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="5"
+      stroke-miterlimit="10" />
+  </svg>
+</div>
+

--- a/test/src/CustomClear.svelte
+++ b/test/src/CustomClear.svelte
@@ -1,0 +1,18 @@
+<style>
+  .customClear {
+    position: absolute;
+    right: var(--clearSelectRight, 10px);
+    top: var(--clearSelectTop, 11px);
+    bottom: var(--clearSelectBottom, 11px);
+    width: var(--clearSelectWidth, 20px);
+    color: var(--clearSelectColor, #c5cacf);
+    flex: none !important;
+  }
+
+  .customClear:hover {
+    color: var(--clearSelectHoverColor, #2c3e50);
+  }
+</style>
+
+<div class="customClear" on:click|preventDefault>Clear</div>
+

--- a/test/src/CustomContainer.svelte
+++ b/test/src/CustomContainer.svelte
@@ -1,0 +1,9 @@
+<script>
+  export let instance;
+</script>
+
+<div class="customContainer"
+  on:click
+  bind:this={instance}>
+  <slot/>
+</div>

--- a/test/src/CustomEmpty.svelte
+++ b/test/src/CustomEmpty.svelte
@@ -1,0 +1,3 @@
+<div class="customEmpty">
+  <slot/>
+</div>

--- a/test/src/CustomGroupItem.svelte
+++ b/test/src/CustomGroupItem.svelte
@@ -1,0 +1,6 @@
+<script>
+  export let getGroupHeaderLabel;
+  export let item;
+</script>
+
+<div class="customGroupItem">{getGroupHeaderLabel(item)}</div>

--- a/test/src/CustomIndicator.svelte
+++ b/test/src/CustomIndicator.svelte
@@ -1,0 +1,1 @@
+<div class="customIndicator">Drop it</div>

--- a/test/src/CustomInput.svelte
+++ b/test/src/CustomInput.svelte
@@ -1,0 +1,18 @@
+<script>
+  export let inputAttributes = {};
+  export let inputStyles = '';
+  export let instance;
+  export let isDisabled = false;
+  export let placeholderText = '';
+  export let value = '';
+</script>
+
+<input
+  {...inputAttributes}
+  class="customInput"
+  bind:this={instance}
+  on:focus
+  bind:value
+  placeholder={placeholderText}
+  style={inputStyles}
+  disabled={isDisabled}/>

--- a/test/src/CustomItemContainer.svelte
+++ b/test/src/CustomItemContainer.svelte
@@ -1,0 +1,3 @@
+<div class="customItemContainer" on:click on:mouseover>
+  <slot/>
+</div>

--- a/test/src/CustomListContainer.svelte
+++ b/test/src/CustomListContainer.svelte
@@ -1,0 +1,7 @@
+<script>
+  export let instance;
+</script>
+
+<div class="customListContainer" bind:this={instance}>
+  <slot/>
+</div>

--- a/test/src/CustomSelectionContainer.svelte
+++ b/test/src/CustomSelectionContainer.svelte
@@ -1,0 +1,3 @@
+<div class="customSelectionContainer" on:focus>
+  <slot/>
+</div>

--- a/test/src/CustomSpinner.svelte
+++ b/test/src/CustomSpinner.svelte
@@ -1,0 +1,1 @@
+<div class="customSpinner">Spin me</div>

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1,7 +1,17 @@
 import getName from 'namey-mcnameface';
 import normalizeHtml from '../utils/normalizeHtml';
 
+import CustomClear from './CustomClear.svelte';
+import CustomContainer from './CustomContainer.svelte';
+import CustomEmpty from './CustomEmpty.svelte';
+import CustomGroupItem from './CustomGroupItem.svelte';
+import CustomIndicator from './CustomIndicator.svelte';
+import CustomInput from './CustomInput.svelte';
 import CustomItem from './CustomItem.svelte';
+import CustomItemContainer from './CustomItemContainer.svelte';
+import CustomListContainer from './CustomListContainer.svelte';
+import CustomSelectionContainer from './CustomSelectionContainer.svelte';
+import CustomSpinner from './CustomSpinner.svelte';
 import Select from '../../src/Select.svelte';
 import List from '../../src/List.svelte';
 import TestIcon from './TestIcon.svelte';
@@ -1581,7 +1591,7 @@ test('when noOptionsMessage is set and there are no items then show message', as
 
   window.dispatchEvent(new KeyboardEvent('keydown', {'key': 'ArrowDown'}));
   await wait(0);
-  t.ok(document.querySelector('.empty').innerHTML === 'SO SO SO SCANDALOUS');
+  t.ok(document.querySelector('.empty').innerHTML.trim() === 'SO SO SO SCANDALOUS');
 
   select.$destroy();
 });
@@ -1649,6 +1659,168 @@ test('when a custom Item component is supplied then use to display each item', a
 
   await handleKeyboard('ArrowDown');
   t.ok(document.querySelector('.customItem_name').innerHTML === 'A Name');
+
+  select.$destroy();
+});
+
+test('when a custom ItemContainer component is supplied then use to wrap each item', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      ItemContainer: CustomItemContainer,
+      getOptionLabel: (option) => option.value,
+      isFocused: true,
+      items
+    }
+  });
+
+  await handleKeyboard('ArrowDown');
+  t.ok(document.querySelector('.customItemContainer').textContent.trim() === items[0].value);
+
+  select.$destroy();
+});
+
+test('when a custom GroupItem component is supplied then use that to display group headers', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      GroupItem: CustomGroupItem,
+      items: itemsWithGroup,
+      isFocused: true,
+      groupBy: (item) => item.group
+    }
+  });
+
+  await handleKeyboard('ArrowDown');
+  t.ok(document.querySelectorAll('.customGroupItem').length === 2);
+
+  select.$destroy();
+});
+
+
+test('when a custom ListContainer component is supplied then use to wrap the list', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      ListContainer: CustomListContainer,
+      getOptionLabel: (option) => option.value,
+      isFocused: true,
+      items
+    }
+  });
+
+  await handleKeyboard('ArrowDown');
+  t.ok(document.querySelector('.customListContainer').children[0].textContent.trim() === items[0].value);
+
+  select.$destroy();
+});
+
+test('when a custom Empty component is supplied then use to wrap the list', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      Empty: CustomEmpty,
+      getOptionLabel: (option) => option.name,
+      isFocused: true,
+      items: [],
+    }
+  });
+
+  await handleKeyboard('ArrowDown');
+  t.ok(document.querySelector('.customEmpty').innerHTML.trim() === 'No options');
+
+  select.$destroy();
+});
+
+test('when a custom SelectionContainer component is supplied then use to wrap the selection', async(t) => {
+  const select = new Select({
+    target,
+    props: {
+      SelectionContainer: CustomSelectionContainer,
+      getOptionLabel: (option) => option.value,
+      getSelectionLabel: (option) => option.value,
+      isFocused: true,
+      items
+    }
+  });
+
+  await handleKeyboard('ArrowDown');
+  await handleKeyboard('Enter');
+  t.ok(document.querySelector('.customSelectionContainer').textContent.trim() === items[0].value);
+
+  select.$destroy();
+});
+
+test('when a custom Input component is supplied then use that for the input', async (t) => {
+const select = new Select({
+    target,
+    props: {
+      Input: CustomInput,
+      items
+    }
+  });
+
+  t.ok(document.querySelector('input.customInput'));
+
+  select.$destroy();
+});
+
+test('when a custom Container component is supplied then use to wrap the select', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      Container: CustomContainer,
+      items
+    }
+  });
+
+  t.ok(document.querySelector('.customContainer input'));
+
+  select.$destroy();
+});
+
+test('when a custom Clear component is supplied then display that', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      Clear: CustomClear,
+      items
+    }
+  });
+
+  await querySelectorClick('.selectContainer');
+  await handleKeyboard('Enter');
+  t.ok(document.querySelector('.customClear'));
+
+  select.$destroy();
+});
+
+test('when a custom Indicator component is supplied then use that for the chevron', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      Indicator: CustomIndicator,
+      items,
+      showChevron: true
+    }
+  });
+
+  t.ok(document.querySelector('.customIndicator'));
+
+  select.$destroy();
+});
+
+test('when a custom Spinner component is supplied then use that for the spinner', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      Spinner: CustomSpinner,
+      items,
+      isWaiting: true
+    }
+  });
+
+  t.ok(document.querySelector('.customSpinner'));
 
   select.$destroy();
 });
@@ -2758,14 +2930,14 @@ test('When noOptionsMessage is changed after List component has been created the
   await wait(0);
   select.$set({listOpen: true});
   await wait(0);
-  t.ok(document.querySelector('.empty').innerHTML === 'FIRST');
+  t.ok(document.querySelector('.empty').innerHTML.trim() === 'FIRST');
   select.$set({noOptionsMessage: 'SECOND'});
   await wait(0);
-  t.ok(document.querySelector('.empty').innerHTML === 'SECOND');
+  t.ok(document.querySelector('.empty').innerHTML.trim() === 'SECOND');
   select.$set({filterText: 'sdfsf ssdfsdfs fs'});
   select.$set({noOptionsMessage: 'THIRD'});
   await wait(0);
-  t.ok(document.querySelector('.empty').innerHTML === 'THIRD');
+  t.ok(document.querySelector('.empty').innerHTML.trim() === 'THIRD');
 
   select.$destroy();
 });
@@ -2929,7 +3101,7 @@ test('When isMulti and multiFullItemClearable then clicking anywhere on the item
   await querySelectorClick('.multiSelectItem');
   await wait(0);
   t.ok(multiSelect.selectedValue[0].label === 'Pizza');
-  
+
   multiSelect.$destroy();
 });
 
@@ -2950,7 +3122,7 @@ test('when loadOptions and items is supplied then list should close on blur', as
   let items=[{value:1, label:1}, {value:2, label:2}];
 	let loadOptions = async(filterText) => {
 		const res = await fetch(`https://api.punkapi.com/v2/beers?beer_name=${filterText}`)
-		const data = await res.json();    
+		const data = await res.json();
     return data.map((beer)=> ({value: beer.id, label: beer.name}));
 	}
 


### PR DESCRIPTION
This allows more fine-grained control over the markup and styling, which, in some cases, may be more preferable than mapping CSS vars or overriding the built-in styles.

I added tests for custom component use and examples for integrating with Bootstrap, but it may be worth creating a library which wraps `svelte-select` and provides all that since it is kind of a lot.

resolves #231