### PR TITLE
Optionally use of default search method

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -62,6 +62,7 @@
     };
   };
 
+  export let useBuiltInSearch = true;
   export let isSearchable = true;
   export let inputStyles = "";
   export let isClearable = true;
@@ -194,11 +195,15 @@
 
             if (!keepItem) return false;
             if (filterText.length < 1) return true;
-            return itemFilter(
-              getOptionLabel(item, filterText),
-              filterText,
-              item
-            );
+            if(useBuiltInSearch){
+              return itemFilter(
+                getOptionLabel(item, filterText),
+                filterText,
+                item
+              );
+            }else{
+              return items;
+            }
           });
     }
 


### PR DESCRIPTION
This will give more freedom to dev if she/he wants to use something like MiniSearch, FuseJS, etc...

I use it like:
```svelte
let dataTest = [
{ ... }, { ... }, { ... }, { ... } //omitted for brevity
];
let filterText = "";
let theArray = []

let miniSearch = new MiniSearch({
      fields: ['tags'],
      storeFields: ['id', 'pid', 'label', 'value'], 
      searchOptions: {
          fuzzy: 0.5,
          prefix: true
      }
  });

  onMount(()=>{
      miniSearch.addAll(dataTest)
  });

  $: {
      theArray = miniSearch.search(filterText);
  }

<Select items={theArray} on:select={handleSelect} bind:filterText useBuiltInSearch={false} ></Select>
```

Pretty easy to write your filter logic this way, thanks @rob-balfre for your effort mantaining this awesome lib, blessings