### PR TITLE
Remove focus when an external field is focused programmatically

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -559,7 +559,7 @@
         if (input) input.focus();
     }
 
-    function handleWindowClick(event) {
+    function handleWindowEvent(event) {
         if (!container) return;
         const eventTarget =
             event.path && event.path.length > 0 ? event.path[0] : event.target;
@@ -819,7 +819,7 @@
     }
 </style>
 
-<svelte:window on:click={handleWindowClick} on:keydown={handleKeyDown} />
+<svelte:window on:click={handleWindowEvent} on:focusin={handleWindowEvent} on:keydown={handleKeyDown} />
 
 <div
     class="selectContainer {containerClasses}"

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1004,6 +1004,25 @@ test(`show ellipsis for overflowing text in a List item`, async (t) => {
   target.style.width = '';
 });
 
+test('focusing in an external textarea should close and blur it', async (t) => {
+  const textarea = document.createElement('textarea');
+  document.body.appendChild(textarea);
+  const select = new Select({
+    target,
+    props: {
+      items,
+    }
+  });
+
+  await querySelectorClick('.selectContainer');
+  t.ok(select.listOpen);
+  textarea.focus();
+  await wait(0);
+  t.ok(!select.listOpen);
+
+  textarea.remove();
+  select.$destroy();
+});
 
 test('clicking between Selects should close and blur other Select', async (t) => {
   const select = new Select({


### PR DESCRIPTION
Hello :wave: 

First of all, thanks a lot for your library, it helped me a lot with my project.

After a user selects an item, another field is focused automatically. The problem is, the `Select` component is still focused and pressing arrows keys are handled by it. Here is a [demo](https://svelte.dev/repl/d94bee3dcbe041aaaf892208d7446005?version=3.12.1) (based on your comment https://github.com/rob-balfre/svelte-select/issues/250#issuecomment-850031105).

I'm not 100% though it was the use case reported by @jquesada2016.

Let me know what you think about that improvement/fix :smile: 

Closes #250 