### PR TITLE
Add labelIdentifier option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ yarn add svelte-select
 - `placeholder: String` Default: `'Select...'`. Placeholder text.
 - `noOptionsMessage: String` Default: `'No options'`. Message to display in list when there are no `items`.
 - `optionIdentifier: String` Default: `'value'`. Override default identifier.
+- `labelIdentifier: String` Default: `'label'`. Override default identifier.
 - `listOpen: Boolean` Default: `false`. Open/close list.
 - `hideEmptyState: Boolean` Default: `false`. Hide list and don't show `noOptionsMessage` when there are no `items`.
 - `containerClasses: String` Default: `''`. Add extra container classes, for example 'global-x local-y'.

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ export interface SelectProps {
   getGroupHeaderLabel?: (option: any) => string;
   getOptionLabel?: (option: any, filterText: string) => string;
   optionIdentifier?: string;
+  labelIdentifier?: string;
   loadOptions?: (filterText: string) => Promise<any[]>;
   hasError?: boolean;
   containerStyles?: string;

--- a/src/List.svelte
+++ b/src/List.svelte
@@ -11,10 +11,11 @@
   export let Item = ItemComponent;
   export let isVirtualList = false;
   export let items = [];
+  export let labelIdentifier = 'label';
   export let getOptionLabel = (option, filterText) => {
-    if (option) return option.isCreator ? `Create \"${filterText}\"` : option.label;
+    if (option) return option.isCreator ? `Create \"${filterText}\"` : option[labelIdentifier];
   };
-  export let getGroupHeaderLabel = (option) => { return option.label };
+  export let getGroupHeaderLabel = (option) => { return option[labelIdentifier] };
   export let itemHeight = 40;
   export let hoverItemIndex = 0;
   export let selectedValue = undefined;

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -37,15 +37,16 @@
   export let getGroupHeaderLabel = option => {
     return option.label;
   };
+  export let labelIdentifier = 'label';
   export let getOptionLabel = (option, filterText) => {
-    return option.isCreator ? `Create \"${filterText}\"` : option.label;
+    return option.isCreator ? `Create \"${filterText}\"` : option[labelIdentifier];
   };
   export let optionIdentifier = "value";
   export let loadOptions = undefined;
   export let hasError = false;
   export let containerStyles = "";
   export let getSelectionLabel = option => {
-    if (option) return option.label;
+    if (option) return option[labelIdentifier];
   };
 
   export let createGroupHeaderItem = groupValue => {

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1532,6 +1532,22 @@ test('when isMulti is true show each item in selectedValue if simple arrays are 
   select.$destroy();
 });
 
+test('when labelIdentifier is set you can pass a string and see the right label', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      items: [{id: 0, name: 'ONE'}, {id: 1, name: 'TWO'}],
+      selectedValue: {id: 0, name: 'ONE'},
+      optionIdentifier: 'id',
+      labelIdentifier: 'name',
+    }
+  });
+
+  t.ok(document.querySelector('.selection').innerHTML === 'ONE');
+
+  select.$destroy();
+});
+
 test('when getValue method is set should use that key to update selectedValue', async (t) => {
   const select = new Select({
     target,


### PR DESCRIPTION
This new option lets you pass a string to select the label value, similar to `optionIdentifier`. I think it will improve consistency and developer experience (right now you have to pass two different functions to get this same behaviour).