### PR TITLE
Mention typescript declaration file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "svelte": "src/index.js",
   "module": "dist/index.mjs",
   "main": "dist/index.js",
+  "types": "./src/index.d.ts",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -cw",


### PR DESCRIPTION
Tiny regression after the update of the project structure. When the declaration file was added originally (https://github.com/rob-balfre/svelte-select/pull/194), it was at the root level. Because now it's not the case anymore, it's important to specify so `tsc` can use it.