### PR TITLE
Fix selecting an item when a parent ancestor is focusable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 /test/public/index.js
 /test/public/bundle.css
 /tests/page/public/build
+/test-results

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 /dist/
 /test/public/index.js
 /test/public/bundle.css
+/tests/page/public/build

--- a/package.json
+++ b/package.json
@@ -14,17 +14,21 @@
     "test": "node test/runner.js",
     "test:browser": "npm run build && serve test/public",
     "gen:docs": "node docs/generate_theming_variables_md.js",
-    "pretest": "npm run build"
+    "pretest": "npm run build",
+    "test:new": "playwright test"
   },
   "devDependencies": {
     "@babel/polyfill": "7.12.1",
+    "@playwright/test": "1.12.3",
     "find-in-files": "^0.5.0",
+    "playwright-chromium": "1.12.3",
     "port-authority": "^1.0.5",
     "puppeteer": "^1.9.0",
     "rollup": "^2.41.2",
     "rollup-plugin-cleaner": "^1.0.0",
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-serve": "1.1.0",
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sirv": "^0.2.2",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  use: {
+    // Browser options
+    headless: false,
+    slowMo: 50,
+
+    // Context options
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+
+    // Artifacts
+    screenshot: "only-on-failure",
+    video: "retry-with-video",
+  },
+  globalSetup: "tests/setup.js",
+};

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -788,7 +788,8 @@
     class:focused={isFocused}
     style={containerStyles}
     on:click={handleClick}
-    bind:this={container}>
+    bind:this={container}
+    tabindex="-1">
     {#if Icon}
         <svelte:component this={Icon} {...iconProps} />
     {/if}

--- a/test/src/Select/Select--default.svelte
+++ b/test/src/Select/Select--default.svelte
@@ -1,3 +1,3 @@
-<div class="selectContainer">
+<div class="selectContainer" tabindex="-1">
   <input autocomplete="off" autocorrect="off" spellcheck="{false}" placeholder="Select...">
 </div>

--- a/tests/container.spec.js
+++ b/tests/container.spec.js
@@ -1,0 +1,46 @@
+const { test, expect } = require("@playwright/test");
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`http://localhost:${process.env.SERVER_PORT}`);
+});
+
+test("the user can navigate through multiple form elements by using Tab", async ({
+  page,
+}) => {
+  const inputs = await page.evaluate(() => {
+    const { Select, items } = window.testExports;
+    const target = document.createElement("main");
+    document.body.appendChild(target);
+
+    const input1 = document.createElement("input");
+    input1.setAttribute("type", "text");
+    input1.classList.add("input1");
+    target.appendChild(input1);
+
+    new Select({
+      target,
+      props: {
+        items,
+      },
+    });
+
+    const input2 = document.createElement("input");
+    input2.setAttribute("type", "text");
+    input2.classList.add("input2");
+    target.appendChild(input2);
+  });
+
+  await page.click(".input1");
+
+  // Pressing Tab gives the focus from input1 to the select component
+  await page.keyboard.press("Tab");
+  await expect(
+    page.$eval(".selectContainer input", (el) => document.activeElement === el)
+  ).resolves.toBe(true);
+
+  // Pressing Tab gives the focus from the select component to input2
+  await page.keyboard.press("Tab");
+  await expect(
+    page.$eval(".input2", (el) => document.activeElement === el)
+  ).resolves.toBe(true);
+});

--- a/tests/page/public/index.html
+++ b/tests/page/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>svelte-select tests</title>
+    <meta charset="utf-8" />
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+
+    <link rel="stylesheet" href="/build/bundle.css" />
+  </head>
+  <body>
+    <main></main>
+    <div id="testTemplate"></div>
+    <div id="extra"></div>
+    <script type="module" src="/build/index.js"></script>
+  </body>
+</html>

--- a/tests/page/src/index.js
+++ b/tests/page/src/index.js
@@ -1,0 +1,15 @@
+import "./reset.css";
+import Select from "../../../src/Select.svelte";
+
+const items = [
+  { value: "chocolate", label: "Chocolate" },
+  { value: "pizza", label: "Pizza" },
+  { value: "cake", label: "Cake" },
+  { value: "chips", label: "Chips" },
+  { value: "ice-cream", label: "Ice Cream" },
+];
+
+window.testExports = {
+  Select,
+  items,
+};

--- a/tests/page/src/reset.css
+++ b/tests/page/src/reset.css
@@ -1,0 +1,27 @@
+html {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}
+
+body {
+  font-size: 14px;
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  min-width: 100%;
+  padding: 20px;
+  margin: 0;
+}
+
+* {
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  width: 390px;
+}

--- a/tests/selectItem.spec.js
+++ b/tests/selectItem.spec.js
@@ -1,0 +1,39 @@
+const { test, expect } = require("@playwright/test");
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`http://localhost:${process.env.SERVER_PORT}`);
+});
+
+test("allows the user to select an item by clicking with a focusable ancestor", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const { Select, items } = window.testExports;
+    const target = document.createElement("main");
+    document.body.appendChild(target);
+
+    const ancestor = document.createElement("div");
+    ancestor.setAttribute("tabindex", "-1");
+    target.appendChild(ancestor);
+
+    const select = new Select({
+      target: ancestor,
+      props: {
+        items,
+      },
+    });
+    window.selectInstance = select;
+  });
+
+  await page.click(".selectContainer");
+  await page.click(".listItem");
+
+  const value = await page.evaluate(() => {
+    return window.selectInstance.value;
+  });
+
+  expect(value).toEqual({
+    value: "chocolate",
+    label: "Chocolate",
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,41 @@
+const http = require("http");
+const ports = require("port-authority");
+const rollup = require("rollup");
+const svelte = require("rollup-plugin-svelte");
+const resolve = require("rollup-plugin-node-resolve");
+const css = require("rollup-plugin-css-only");
+const serve = require("rollup-plugin-serve");
+
+module.exports = async () => {
+  const port = await ports.find(1234);
+  process.env.SERVER_PORT = port;
+
+  const bundle = await rollup.rollup({
+    input: "./tests/page/src/index.js",
+    plugins: [
+      svelte({
+        emitCss: true,
+        compilerOptions: {
+          accessors: true,
+          dev: true,
+        },
+      }),
+      css({ output: { dir: "./tests/page/public/build" } }),
+      resolve(),
+      serve({
+        contentBase: "./tests/page/public",
+        host: "localhost",
+        port,
+      }),
+    ],
+  });
+
+  await bundle.write({
+    output: {
+      dir: "./tests/page/public/build",
+      inlineDynamicImports: true,
+    },
+  });
+
+  return () => bundle.close();
+};


### PR DESCRIPTION
Hello :wave:

Here is a proposed fix for closing #278.

Part of the work also introduces `playwright` to be able to test that fix. With the current test, because the click is simulated, the browser doesn't react exactly the same. Ideally, with the current tests, all interactions should be triggered by using `puppeteer`. I found it easier to set up Playwright instead of fixing the current ones.

Here are some advantages:
- based on the current tests -> ability to migrate the current tests
- compilation when the tests are run -> no need to have a `pretest` script
- nice runner -> calling `page.pause()` helps to debug at whatever stage
- the page is loaded before each test, no need to clean by hand

Let me know what do you think about it. If that's fine for you, current tests can be migrated.

Closes #278