### PR TITLE
Add support for non-selectable items

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A select/autocomplete component for Svelte apps.  With support for grouping, fil
 
 🌱 [Simple demo](https://svelte.dev/repl/a859c2ba7d1744af9c95037c48989193?version=3.12.1)
 
-🌻 [Advanced demo](https://svelte.dev/repl/3e032a58c3974d07b7818c0f817a06a3?version=3.20.1)
+🌻 [Advanced demo](https://svelte.dev/repl/9c79ce1329f749c4a4e84f1c2f480653?version=3.20.1)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ yarn add svelte-select
 <Select {items} {value} on:select={handleSelect}></Select>
 ```
 
+To provide an item that is not selectable, include `selectable: false` in the item. Example:
+
+```javascript
+{value: 'pizza', label: 'Pizza', selectable: false}
+```
 
 ## API
 

--- a/docs/theming_variables.md
+++ b/docs/theming_variables.md
@@ -49,6 +49,7 @@ You can override the following variables to style a Select component.
 - `--itemHoverColor`
 - `--itemIsActiveBG`
 - `--itemIsActiveColor`
+- `--itemIsNotSelectableColor`
 - `--itemPadding`
 - `--listBackground`
 - `--listBorder`

--- a/src/Item.svelte
+++ b/src/Item.svelte
@@ -2,6 +2,7 @@
     export let isActive = false;
     export let isFirst = false;
     export let isHover = false;
+    export let isSelectable = false;
     export let getOptionLabel = undefined;
     export let item = undefined;
     export let filterText = '';
@@ -24,6 +25,9 @@
         }
         if (item.isGroupItem) {
             classes.push('groupItem');
+        }
+        if (!isSelectable) {
+            classes.push('notSelectable');
         }
         itemClasses = classes.join(' ');
     }
@@ -56,6 +60,10 @@
     .item.active {
         background: var(--itemIsActiveBG, #007aff);
         color: var(--itemIsActiveColor, #fff);
+    }
+
+   .item.notSelectable {
+        color: var(--itemIsNotSelectableColor, #999);
     }
 
     .item.first {

--- a/src/List.svelte
+++ b/src/List.svelte
@@ -119,9 +119,7 @@
                 hoverItemIndex = hoverItemIndex + increment;
             }
 
-            isNonSelectableItem =
-                items[hoverItemIndex].isGroupHeader &&
-                !items[hoverItemIndex].isSelectable;
+            isNonSelectableItem = !isItemSelectable(items[hoverItemIndex]);
         }
 
         await tick();
@@ -206,6 +204,12 @@
 
     function isItemHover(hoverItemIndex, item, itemIndex, items) {
         return hoverItemIndex === itemIndex || items.length === 1;
+    }
+
+    function isItemSelectable(item) {
+        return (item.isGroupHeader && item.isSelectable) ||
+            item.selectable ||
+            !item.hasOwnProperty('selectable') // Default; if `selectable` was not specified, the object is selectable
     }
 
     let listStyle;

--- a/src/List.svelte
+++ b/src/List.svelte
@@ -94,7 +94,7 @@
 
         if (item.isCreator) {
             dispatch('itemCreated', filterText);
-        } else {
+        } else if (isItemSelectable(item)) {
             activeItemIndex = i;
             hoverItemIndex = i;
             handleSelect(item);
@@ -203,7 +203,7 @@
     }
 
     function isItemHover(hoverItemIndex, item, itemIndex, items) {
-        return hoverItemIndex === itemIndex || items.length === 1;
+        return isItemSelectable(item) && (hoverItemIndex === itemIndex || items.length === 1);
     }
 
     function isItemSelectable(item) {

--- a/src/List.svelte
+++ b/src/List.svelte
@@ -302,7 +302,8 @@
                     {getOptionLabel}
                     isFirst={isItemFirst(i)}
                     isActive={isItemActive(item, value, optionIdentifier)}
-                    isHover={isItemHover(hoverItemIndex, item, i, items)} />
+                    isHover={isItemHover(hoverItemIndex, item, i, items)}
+                    isSelectable={isItemSelectable(item)} />
             </div>
         </svelte:component>
     {:else}
@@ -323,7 +324,8 @@
                         {getOptionLabel}
                         isFirst={isItemFirst(i)}
                         isActive={isItemActive(item, value, optionIdentifier)}
-                        isHover={isItemHover(hoverItemIndex, item, i, items)} />
+                        isHover={isItemHover(hoverItemIndex, item, i, items)}
+                        isSelectable={isItemSelectable(item)} />
                 </div>
             {/if}
         {:else}

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1248,8 +1248,7 @@ test('clicking group header should not make a selected', async (t) => {
   select.$destroy();
 });
 
-// TODO Remove .only
-test.only('clicking an item with selectable: false should not make a selected', async (t) => {
+test('clicking an item with selectable: false should not make a selected', async (t) => {
   const select = new Select({
     target,
     props: {
@@ -1268,11 +1267,10 @@ test.only('clicking an item with selectable: false should not make a selected', 
   await querySelectorClick('.listItem:nth-child(4)')
   t.ok(!select.value);
 
-  //select.$destroy();
+  select.$destroy();
 });
 
-// TODO Remove .only
-test.only('clicking an item with selectable not specified should make a selected', async (t) => {
+test('clicking an item with selectable not specified should make a selected', async (t) => {
   const select = new Select({
     target,
     props: {
@@ -1290,8 +1288,7 @@ test.only('clicking an item with selectable not specified should make a selected
   select.$destroy();
 });
 
-// TODO Remove .only
-test.only('clicking an item with selectable: true should make a selected', async (t) => {
+test('clicking an item with selectable: true should make a selected', async (t) => {
   const select = new Select({
     target,
     props: {

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -114,6 +114,13 @@ const itemsWithGroupIds = [
   {_id: 'ice-cream', name: 'Ice Cream', groupie: 'Sweet'}
 ];
 
+const itemsWithSelectable = [
+  {value: 'notSelectable1', label: 'NotSelectable1', selectable: false},
+  {value: 'selectableDefault', label: 'SelectableDefault'},
+  {value: 'selectableTrue', label: 'SelectableTrue', selectable: true},
+  {value: 'notSelectable2', label: 'NotSelectable2', selectable: false}
+];
+
 function itemsPromise() {
   return new Promise(resolve => {
     setTimeout(() => {
@@ -1239,6 +1246,36 @@ test('clicking group header should not make a selected', async (t) => {
   t.ok(!select.value);
 
   select.$destroy();
+});
+
+test.only('clicking an item with selectable: false should not make a selected', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      listOpen: true,
+      items: itemsWithSelectable
+    }
+  });
+
+  await wait(0);
+
+  // notSelectable1
+  await querySelectorClick('.listItem:nth-child(1)')
+  t.ok(!select.value);
+
+  // notSelectable2
+  await querySelectorClick('.listItem:nth-child(4)')
+  t.ok(!select.value);
+
+  // selectableDefault
+  await querySelectorClick('.listItem:nth-child(2)')
+  t.ok(select.value == 'selectableDefault');
+
+  // selectableDefault
+  await querySelectorClick('.listItem:nth-child(2)')
+  t.ok(select.value == 'selectableTrue');
+
+  //select.$destroy();
 });
 
 test('when groupBy, no active item and keydown enter is fired then list should close without selecting item', async (t) => {

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1248,6 +1248,7 @@ test('clicking group header should not make a selected', async (t) => {
   select.$destroy();
 });
 
+// TODO Remove .only
 test.only('clicking an item with selectable: false should not make a selected', async (t) => {
   const select = new Select({
     target,
@@ -1267,15 +1268,46 @@ test.only('clicking an item with selectable: false should not make a selected', 
   await querySelectorClick('.listItem:nth-child(4)')
   t.ok(!select.value);
 
-  // selectableDefault
-  await querySelectorClick('.listItem:nth-child(2)')
-  t.ok(select.value == 'selectableDefault');
-
-  // selectableDefault
-  await querySelectorClick('.listItem:nth-child(2)')
-  t.ok(select.value == 'selectableTrue');
-
   //select.$destroy();
+});
+
+// TODO Remove .only
+test.only('clicking an item with selectable not specified should make a selected', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      listOpen: true,
+      items: itemsWithSelectable
+    }
+  });
+
+  await wait(0);
+
+  // selectableDefault
+  await querySelectorClick('.listItem:nth-child(2)')
+  t.ok(select.value && select.value.value == 'selectableDefault');
+
+  select.$destroy();
+});
+
+// TODO Remove .only
+test.only('clicking an item with selectable: true should make a selected', async (t) => {
+  const select = new Select({
+    target,
+    props: {
+      listOpen: true,
+      items: itemsWithSelectable
+    }
+  });
+
+  await wait(0);
+
+  // selectableDefault
+  await querySelectorClick('.listItem:nth-child(3)')
+  console.log(select.value)
+  t.ok(select.value && select.value.value == 'selectableTrue');
+
+  select.$destroy();
 });
 
 test('when groupBy, no active item and keydown enter is fired then list should close without selecting item', async (t) => {


### PR DESCRIPTION
I have a use case where we want to show our users possible options that they cannot currently select. To handle this, I've added the ability to specify `selectable: false` for items.

This should be an addition to the API, not a change, so it shouldn't break existing usages.

Example:

```javascript
const items = [
  {value: 'notSelectable', label: 'NotSelectable', selectable: false},  // Will not be selectable
  {value: 'selectableDefault', label: 'SelectableDefault'},             // Will be selectable
  {value: 'selectableTrue', label: 'SelectableTrue', selectable: true}, // Will be selectable
];
```

The `Item` component now also exposes an additional boolean parameter, `isSelectable`. In the default implementation, non-selectable items have their text color set to `--itemIsNotSelectableColor`, or `#999` if `--itemIsNotSelectableColor` is not provided.

<img width="1109" alt="svelte-select_tests" src="https://user-images.githubusercontent.com/221148/129665971-a835ba13-2e6f-443b-9a4a-603a2105316e.png">