### PR TITLE
Deprecated isSearchable field v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## 4.4.0
 
-* Added support for non-selectable items - thanks to @mpdaugherty
+* Added support for non-selectable items - thanks to @mpdaugherty 
 
 ## 4.3.1
 
@@ -32,7 +32,7 @@
 
 ## 4.2.7
 
-* Bug fixes for #278, #279, #280, #285 - thanks to @davidfou
+* Bug fixes for #278, #279, #280, #285 - thanks to @davidfou 
 
 ## 4.2.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # svelte-select changelog
 
+## 4.5.0
+
+* Renamed option `isSearchable` to `isFilterable`. `isSearchable` is now deprecated
+    and will have different behaviour in the future.
+
 ## 4.4.3
 
 * listOffset was missing from typings - thanks to @blake-regalia
@@ -14,7 +19,7 @@
 
 ## 4.4.0
 
-* Added support for non-selectable items - thanks to @mpdaugherty 
+* Added support for non-selectable items - thanks to @mpdaugherty
 
 ## 4.3.1
 
@@ -27,7 +32,7 @@
 
 ## 4.2.7
 
-* Bug fixes for #278, #279, #280, #285 - thanks to @davidfou 
+* Bug fixes for #278, #279, #280, #285 - thanks to @davidfou
 
 ## 4.2.6
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ yarn add svelte-select
 - `isCreatable: Boolean` Default: `false`. Can create new item(s) to be added to `value`.
 - `isDisabled: Boolean` Default: `false`. Disable select.
 - `isMulti: Boolean` Default: `false`. Enable multi-select, `value` becomes an array of selected items.
-- `isSearchable: Boolean` Default: `true`. Enable search/filtering of `items` via `filterText`.
+- `isFilterable: Boolean` Default: `true`. Enable filtering of `items` via `filterText`.
+- `isSearchable: Boolean` Default: `true`. Enable searching of `items` via `filterText`.
 - `isGroupHeaderSelectable: Boolean` Default: `false`. Enable selectable group headers in `items` (see adv demo).
 - `listPlacement: String` Default: `'auto'`. When `'auto'` displays either `'top'` or `'bottom'` depending on viewport.
 - `hasError: Boolean` Default: `false`. Show/hide error styles around select input (red border by default).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-select",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "repository": "https://rob-balfre@github.com/rob-balfre/svelte-select.git",
   "description": "A <Select> component for Svelte apps",
   "svelte": "src/index.js",

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -65,7 +65,8 @@
         return filteredItems;
     };
 
-    export let isSearchable = true;
+    export let isSearchable; // Deprecated. Use isFilterable instead.
+    export let isFilterable = true;
     export let inputStyles = '';
     export let isClearable = true;
     export let isWaiting = false;
@@ -92,6 +93,15 @@
     export let Selection = _Selection;
     export let MultiSelection = _MultiSelection;
     export let VirtualList = _VirtualList;
+
+    $: {
+        if (isSearchable !== undefined) {
+            isFilterable = isSearchable;
+            console.warn(
+                'isSearchable is deprecated and will change in the future. Use isFilterable instead.'
+            );
+        }
+    }
 
     function filterMethod(args) {
         if (args.loadOptions && args.filterText.length > 0) return;
@@ -236,7 +246,7 @@
             _inputAttributes.id = id;
         }
 
-        if (!isSearchable) {
+        if (!isFilterable) {
             _inputAttributes.readonly = true;
         }
     }
@@ -333,7 +343,7 @@
     }
 
     $: {
-        if (inputAttributes || !isSearchable) assignInputAttributes();
+        if (inputAttributes || !isFilterable) assignInputAttributes();
     }
 
     $: {
@@ -873,9 +883,7 @@
         class="a11yText">
         {#if isFocused}
             <span id="aria-selection">{ariaSelection}</span>
-            <span id="aria-context">
-                {ariaContext}
-            </span>
+            <span id="aria-context"> {ariaContext} </span>
         {/if}
     </span>
 
@@ -896,7 +904,7 @@
     {/if}
 
     <input
-        readOnly={!isSearchable}
+        readOnly={!isFilterable}
         {..._inputAttributes}
         bind:this={input}
         on:focus={handleFocus}
@@ -923,7 +931,7 @@
         </div>
     {/if}
 
-    {#if !showClearIcon && (showIndicator || (showChevron && !value) || (!isSearchable && !isDisabled && !isWaiting && ((showSelectedItem && !isClearable) || !showSelectedItem)))}
+    {#if !showClearIcon && (showIndicator || (showChevron && !value) || (!isFilterable && !isDisabled && !isWaiting && ((showSelectedItem && !isClearable) || !showSelectedItem)))}
         <div class="indicator" aria-hidden="true">
             {#if indicatorSvg}
                 {@html indicatorSvg}

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -883,7 +883,9 @@
         class="a11yText">
         {#if isFocused}
             <span id="aria-selection">{ariaSelection}</span>
-            <span id="aria-context"> {ariaContext} </span>
+            <span id="aria-context">
+                {ariaContext}
+            </span>
         {/if}
     </span>
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,7 @@ export interface SelectProps {
   createGroupHeaderItem?: (groupValue: any) => any;
   createItem?: (filterText: string) => any;
   isSearchable?: boolean;
+  isFilterable?: boolean;
   inputStyles?: string;
   isClearable?: boolean;
   isWaiting?: boolean;

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -565,7 +565,7 @@ test('focus on Select input updates focus state', async (t) => {
       items
     }
   });
-
+  
   document.querySelector('.selectContainer input').focus();
 
   t.ok(select.isFocused);
@@ -1224,7 +1224,7 @@ test('items should be grouped by groupBy expression', async (t) => {
 
   let title = document.querySelector('.listGroupTitle').innerHTML;
   t.ok(title === 'Sweet');
-  let item = document.querySelector('.listItem .item').innerHTML;
+  let item = document.querySelector('.listItem .item').innerHTML; 
   t.ok(item === 'Chocolate');
   select.$destroy();
 });
@@ -2925,7 +2925,7 @@ test('When loadOptions promise is resolved then dispatch loaded', async (t) => {
   await wait(0);
   select.$set({filterText: 'test'});
   await wait(500);
-
+  
   t.equal(loadedEventData.detail.items[0].value, 'a');
   t.equal(errorEventData, undefined);
 
@@ -3062,7 +3062,7 @@ test('When isMulti and multiFullItemClearable then clicking anywhere on the item
   await querySelectorClick('.multiSelectItem');
   await wait(0);
   t.ok(multiSelect.value[0].label === 'Pizza');
-
+  
   multiSelect.$destroy();
 });
 
@@ -3077,7 +3077,7 @@ test('When isMulti and filterText then items should filter out already selected 
   });
 
   t.ok(multiSelect.getFilteredItems().length === 3);
-
+  
   multiSelect.$destroy();
 });
 
@@ -3087,7 +3087,7 @@ test('when loadOptions and items is supplied then list should close on blur', as
   let items=[{value:1, label:1}, {value:2, label:2}];
 	let loadOptions = async(filterText) => {
 		const res = await fetch(`https://api.punkapi.com/v2/beers?beer_name=${filterText}`)
-		const data = await res.json();
+		const data = await res.json();    
     return data.map((beer)=> ({value: beer.id, label: beer.name}));
 	}
 
@@ -3121,7 +3121,7 @@ test('when isCreatable and item created then event "itemCreated" should dispatch
       isMulti: true
     }
   });
-
+  
   let eventDetail;
   select.$on('itemCreated', (event) => {
     eventDetail = event.detail;
@@ -3150,7 +3150,7 @@ test('when loadOptions response returns cancelled true then dont end loading sta
 
   select.$set({filterText: 'Juniper'});
   await wait(0);
-
+  
 
   select.$destroy();
 });
@@ -3164,7 +3164,7 @@ test('when ClearItem replace clear icon', async (t) => {
       value: {value: 'chips', label: 'Chips'}
     }
   });
-
+  
   t.ok(target.querySelector('.testClearIcon'));
 
   select.$destroy();
@@ -3220,7 +3220,7 @@ test('when switching between isMulti true/false ensure Select continues working'
 
   t.ok(JSON.stringify(select.value) === JSON.stringify([{value: 'chips', label: 'Chips'}]));
   t.ok(Array.isArray(select.value));
-
+  
   select.isMulti = false;
   select.loadOptions = null;
   select.items = [...items];
@@ -3308,7 +3308,7 @@ test('when loadOptions and value then items should show on promise resolve',asyn
 
   await wait(300);
   t.ok(select.getFilteredItems().length === 3);
-
+  
   select.$destroy();
 });
 
@@ -3336,7 +3336,7 @@ test('when loadOptions, isMulti and value then filterText should remain on promi
 
   await wait(300);
   t.ok(select.filterText === 'test');
-
+  
   select.$destroy();
 });
 
@@ -3394,7 +3394,7 @@ test('When items are updated post onMount ensure filtering still works', async (
 
   t.ok(select.getFilteredItems().length === 1);
   t.ok(select.getFilteredItems()[0].value === 'Two');
-
+  
   select.$destroy();
 });
 
@@ -3415,8 +3415,8 @@ test('When grouped items are updated post onMount ensure filtering still works',
   t.ok(select.getFilteredItems().length === 2);
   t.ok(select.getFilteredItems()[0].label === '2nd Group');
   t.ok(select.getFilteredItems()[1].label === 'Two');
-
-
+  
+  
   select.$destroy();
 });
 
@@ -3427,7 +3427,7 @@ test('When groupBy and value selected ensure filtering still works', async (t) =
     props: {
       items: itemsWithGroup,
       groupBy: (item) => item.group,
-
+      
     },
   });
 
@@ -3453,7 +3453,7 @@ test('When value selected and filterText then ensure selecting the active value 
   select.listOpen = true;
   select.filterText = 'Cake';
   document.querySelector('.listItem .item').click();
-
+  
   t.ok(select.filterText.length === 0);
 
   select.$destroy();
@@ -3533,7 +3533,7 @@ test('When isMulti on:select events should fire on each item removal (including 
   document.querySelector('.multiSelectItem_clear').click();
   await wait(0);
   t.ok(events.length === 2);
-
+  
   select.$destroy();
 });
 
@@ -3595,7 +3595,7 @@ test('When no value then hidden field should also have no value', async (t) => {
     props: {
       inputAttributes: { name: 'Foods' },
       items: items,
-
+      
     },
   });
 
@@ -3666,7 +3666,7 @@ test('When listOpen then aria-context describes highlighted item', async (t) => 
   t.ok(aria.innerHTML.includes('Chocolate'));
   await handleKeyboard('ArrowDown');
   t.ok(aria.innerHTML.includes('Pizza'));
-
+  
   select.$destroy();
 });
 
@@ -3682,7 +3682,7 @@ test('When listOpen and value then aria-selection describes value', async (t) =>
 
   let aria = document.querySelector('#aria-selection');
   t.ok(aria.innerHTML.includes('Cake'));
-
+  
   select.$destroy();
 });
 
@@ -3700,7 +3700,7 @@ test('When listOpen, value and isMulti then aria-selection describes value', asy
   let aria = document.querySelector('#aria-selection');
   t.ok(aria.innerHTML.includes('Cake'));
   t.ok(aria.innerHTML.includes('Pizza'));
-
+    
   select.$destroy();
 });
 
@@ -3717,7 +3717,7 @@ test('When ariaValues and value supplied, then aria-selection uses default updat
 
   let aria = document.querySelector('#aria-selection');
   t.equal(aria.innerHTML, 'Yummy Pizza in my tummy!');
-
+  
   select.$destroy();
 });
 
@@ -3733,7 +3733,7 @@ test('When ariaListOpen, listOpen, then aria-context uses default updated', asyn
 
   let aria = document.querySelector('#aria-context');
   t.equal(aria.innerHTML, 'label: Chocolate, count: 5');
-
+    
   select.$destroy();
 });
 
@@ -3749,7 +3749,7 @@ test('When ariaFocused, focused value supplied, then aria-context uses default u
 
   let aria = document.querySelector('#aria-context');
   t.equal(aria.innerHTML, 'nothing to see here.');
-
+    
   select.$destroy();
 });
 
@@ -3765,7 +3765,7 @@ test('When id supplied then add to input', async (t) => {
 
   let aria = document.querySelector('input[type="text"]');
   t.equal(aria.id, 'foods');
-
+    
   select.$destroy();
 });
 

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -565,7 +565,7 @@ test('focus on Select input updates focus state', async (t) => {
       items
     }
   });
-  
+
   document.querySelector('.selectContainer input').focus();
 
   t.ok(select.isFocused);
@@ -1130,7 +1130,7 @@ test('should not be able to search when searching is disabled', async (t) => {
     target,
     props: {
       items,
-      isSearchable: false
+      isFilterable: false
     }
   });
 
@@ -1148,7 +1148,7 @@ test('should display indicator when searching is disabled', async (t) => {
     target,
     props: {
       items,
-      isSearchable: false
+      isFilterable: false
     }
   });
 
@@ -1224,7 +1224,7 @@ test('items should be grouped by groupBy expression', async (t) => {
 
   let title = document.querySelector('.listGroupTitle').innerHTML;
   t.ok(title === 'Sweet');
-  let item = document.querySelector('.listItem .item').innerHTML; 
+  let item = document.querySelector('.listItem .item').innerHTML;
   t.ok(item === 'Chocolate');
   select.$destroy();
 });
@@ -2925,7 +2925,7 @@ test('When loadOptions promise is resolved then dispatch loaded', async (t) => {
   await wait(0);
   select.$set({filterText: 'test'});
   await wait(500);
-  
+
   t.equal(loadedEventData.detail.items[0].value, 'a');
   t.equal(errorEventData, undefined);
 
@@ -3062,7 +3062,7 @@ test('When isMulti and multiFullItemClearable then clicking anywhere on the item
   await querySelectorClick('.multiSelectItem');
   await wait(0);
   t.ok(multiSelect.value[0].label === 'Pizza');
-  
+
   multiSelect.$destroy();
 });
 
@@ -3077,7 +3077,7 @@ test('When isMulti and filterText then items should filter out already selected 
   });
 
   t.ok(multiSelect.getFilteredItems().length === 3);
-  
+
   multiSelect.$destroy();
 });
 
@@ -3087,7 +3087,7 @@ test('when loadOptions and items is supplied then list should close on blur', as
   let items=[{value:1, label:1}, {value:2, label:2}];
 	let loadOptions = async(filterText) => {
 		const res = await fetch(`https://api.punkapi.com/v2/beers?beer_name=${filterText}`)
-		const data = await res.json();    
+		const data = await res.json();
     return data.map((beer)=> ({value: beer.id, label: beer.name}));
 	}
 
@@ -3121,7 +3121,7 @@ test('when isCreatable and item created then event "itemCreated" should dispatch
       isMulti: true
     }
   });
-  
+
   let eventDetail;
   select.$on('itemCreated', (event) => {
     eventDetail = event.detail;
@@ -3150,7 +3150,7 @@ test('when loadOptions response returns cancelled true then dont end loading sta
 
   select.$set({filterText: 'Juniper'});
   await wait(0);
-  
+
 
   select.$destroy();
 });
@@ -3164,7 +3164,7 @@ test('when ClearItem replace clear icon', async (t) => {
       value: {value: 'chips', label: 'Chips'}
     }
   });
-  
+
   t.ok(target.querySelector('.testClearIcon'));
 
   select.$destroy();
@@ -3220,7 +3220,7 @@ test('when switching between isMulti true/false ensure Select continues working'
 
   t.ok(JSON.stringify(select.value) === JSON.stringify([{value: 'chips', label: 'Chips'}]));
   t.ok(Array.isArray(select.value));
-  
+
   select.isMulti = false;
   select.loadOptions = null;
   select.items = [...items];
@@ -3230,12 +3230,12 @@ test('when switching between isMulti true/false ensure Select continues working'
   select.$destroy();
 });
 
-test('when isSearchable is false then input should be readonly', async (t) => {
+test('when isFilterable is false then input should be readonly', async (t) => {
   const select = new Select({
     target,
     props: {
       items,
-      isSearchable: false
+      isFilterable: false
     }
   });
 
@@ -3308,7 +3308,7 @@ test('when loadOptions and value then items should show on promise resolve',asyn
 
   await wait(300);
   t.ok(select.getFilteredItems().length === 3);
-  
+
   select.$destroy();
 });
 
@@ -3336,7 +3336,7 @@ test('when loadOptions, isMulti and value then filterText should remain on promi
 
   await wait(300);
   t.ok(select.filterText === 'test');
-  
+
   select.$destroy();
 });
 
@@ -3394,7 +3394,7 @@ test('When items are updated post onMount ensure filtering still works', async (
 
   t.ok(select.getFilteredItems().length === 1);
   t.ok(select.getFilteredItems()[0].value === 'Two');
-  
+
   select.$destroy();
 });
 
@@ -3415,8 +3415,8 @@ test('When grouped items are updated post onMount ensure filtering still works',
   t.ok(select.getFilteredItems().length === 2);
   t.ok(select.getFilteredItems()[0].label === '2nd Group');
   t.ok(select.getFilteredItems()[1].label === 'Two');
-  
-  
+
+
   select.$destroy();
 });
 
@@ -3427,7 +3427,7 @@ test('When groupBy and value selected ensure filtering still works', async (t) =
     props: {
       items: itemsWithGroup,
       groupBy: (item) => item.group,
-      
+
     },
   });
 
@@ -3453,7 +3453,7 @@ test('When value selected and filterText then ensure selecting the active value 
   select.listOpen = true;
   select.filterText = 'Cake';
   document.querySelector('.listItem .item').click();
-  
+
   t.ok(select.filterText.length === 0);
 
   select.$destroy();
@@ -3533,7 +3533,7 @@ test('When isMulti on:select events should fire on each item removal (including 
   document.querySelector('.multiSelectItem_clear').click();
   await wait(0);
   t.ok(events.length === 2);
-  
+
   select.$destroy();
 });
 
@@ -3595,7 +3595,7 @@ test('When no value then hidden field should also have no value', async (t) => {
     props: {
       inputAttributes: { name: 'Foods' },
       items: items,
-      
+
     },
   });
 
@@ -3666,7 +3666,7 @@ test('When listOpen then aria-context describes highlighted item', async (t) => 
   t.ok(aria.innerHTML.includes('Chocolate'));
   await handleKeyboard('ArrowDown');
   t.ok(aria.innerHTML.includes('Pizza'));
-  
+
   select.$destroy();
 });
 
@@ -3682,7 +3682,7 @@ test('When listOpen and value then aria-selection describes value', async (t) =>
 
   let aria = document.querySelector('#aria-selection');
   t.ok(aria.innerHTML.includes('Cake'));
-  
+
   select.$destroy();
 });
 
@@ -3700,7 +3700,7 @@ test('When listOpen, value and isMulti then aria-selection describes value', asy
   let aria = document.querySelector('#aria-selection');
   t.ok(aria.innerHTML.includes('Cake'));
   t.ok(aria.innerHTML.includes('Pizza'));
-    
+
   select.$destroy();
 });
 
@@ -3717,7 +3717,7 @@ test('When ariaValues and value supplied, then aria-selection uses default updat
 
   let aria = document.querySelector('#aria-selection');
   t.equal(aria.innerHTML, 'Yummy Pizza in my tummy!');
-  
+
   select.$destroy();
 });
 
@@ -3733,7 +3733,7 @@ test('When ariaListOpen, listOpen, then aria-context uses default updated', asyn
 
   let aria = document.querySelector('#aria-context');
   t.equal(aria.innerHTML, 'label: Chocolate, count: 5');
-    
+
   select.$destroy();
 });
 
@@ -3749,7 +3749,7 @@ test('When ariaFocused, focused value supplied, then aria-context uses default u
 
   let aria = document.querySelector('#aria-context');
   t.equal(aria.innerHTML, 'nothing to see here.');
-    
+
   select.$destroy();
 });
 
@@ -3765,7 +3765,7 @@ test('When id supplied then add to input', async (t) => {
 
   let aria = document.querySelector('input[type="text"]');
   t.equal(aria.id, 'foods');
-    
+
   select.$destroy();
 });
 


### PR DESCRIPTION
This is **Part 1** of a 2 part MR that aims to add search functionality in addition to filtering. For this reason I wanted to definitely differentiate between `isSearchable` and `isFilterable` and properly deprecate the old config option. I've tagged this as version `2.5.0` (the next sub-major version). I also explicitly double-checked that all tests pass with both options and that the option name change doesn't break anything.

The second MR will come soon after I finish the modifications. I'll tag that as `v5.0.0` as it is changing the library API.

P.S. I'm also available on Discord for a quick chat if required _(`itay-grudev#2347`)_.
P.P.S. I intentionally committed some whitespace changes, just because it's really annoying to manually remove them from MRs every time after my IDE automatically fixes it.