### PR TITLE
check event.relatedTarget in handleWindowEvent

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -540,7 +540,9 @@
         if (!container) return;
         const eventTarget =
             event.path && event.path.length > 0 ? event.path[0] : event.target;
-        if (container.contains(eventTarget)) return;
+        if (container.contains(eventTarget) || container.contains(event.relatedTarget)) {
+            return;
+        }
         isFocused = false;
         listOpen = false;
         activeValue = undefined;


### PR DESCRIPTION
This _might_ close #339.

I found that when using in sveltekit and clicking on the scrollbar, the `event.target` was `body`, but `event.relatedTarget` was `input#select-input`, which is I think the expected element. 

I'm not sure why that behavior is different in sveltekit so it might actually be an upstream problem.

But, by checking if `container` contains `event.relatedTarget` we're back to expected behavior in sveltekit.