### PR TITLE
Fix event handling bug

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -540,7 +540,8 @@
         if (!container) return;
         const eventTarget =
             event.path && event.path.length > 0 ? event.path[0] : event.target;
-        if (container.contains(eventTarget)) return;
+        const relatedTarget = event.relatedTarget;
+        if (container.contains(eventTarget) || container.contains(relatedTarget)) return;
         isFocused = false;
         listOpen = false;
         activeValue = undefined;
@@ -864,7 +865,7 @@
     class:disabled={isDisabled}
     class:focused={isFocused}
     style={containerStyles}
-    on:click={handleClick}
+    on:click|preventDefault={handleClick}
     bind:this={container}>
     <span
         aria-live="polite"


### PR DESCRIPTION
Previous behavior:
When clicking the indicator element the `handleClick` event would fire twice showing and hiding the select list in the same frame.
`handleWindowEvent` treated clicking on the indicator as clicking outside the input box.

New behavior:
`handleClick` always fires once.
`handleWindowEvent` now treats the indicator and the input field equally.

Minimal bug reproduction: https://svelte.dev/repl/670585758e3a4df0a98daf368ed9a05c?version=3.44.1