### PR TITLE
Fix of jumping container when scrolling with keyboard

### DIFF
--- a/src/List.svelte
+++ b/src/List.svelte
@@ -223,7 +223,7 @@
 
         if (
             listPlacement === 'top' ||
-            (listPlacement === 'auto' && isOutOfViewport(container).bottom)
+            (listPlacement === 'auto' && isOutOfViewport(parent, container).bottom)
         ) {
             listStyle += `bottom:${height + listOffset}px;`;
         } else {

--- a/src/utils/isOutOfViewport.js
+++ b/src/utils/isOutOfViewport.js
@@ -1,14 +1,16 @@
-export default function (elem) {
-    const bounding = elem.getBoundingClientRect();
+export default function (parent, container) {
+    const parentBounding = parent.getBoundingClientRect();
+    const boundingContainer = container.getBoundingClientRect();
     const out = {};
 
-    out.top = bounding.top < 0;
-    out.left = bounding.left < 0;
+    out.top = parentBounding.top < 0;
+    out.left = parentBounding.left < 0;
     out.bottom =
-        bounding.bottom + bounding.height >
+        parentBounding.bottom + boundingContainer.height >
         (window.innerHeight || document.documentElement.clientHeight);
+
     out.right =
-        bounding.right >
+        parentBounding.right >
         (window.innerWidth || document.documentElement.clientWidth);
     out.any = out.top || out.left || out.bottom || out.right;
 


### PR DESCRIPTION
The container is jumping when user scrolls in it using keyboard:
![ezgif-3-1c96f004fbde](https://user-images.githubusercontent.com/3720262/142618805-c7ca6665-6c80-4dea-a673-88967a18e74c.gif)

Calculations of bounding in isOutOfViewport.js are fixed.
