### PR TITLE
placeholderAlwaysShow not working without isMulti

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -391,7 +391,7 @@
         }
     }
 
-    $: showSelectedItem = value && filterText.length === 0;
+    $: showSelectedItem = value && filterText.length === 0 && !placeholderAlwaysShow;
     $: showClearIcon =
         showSelectedItem && isClearable && !isDisabled && !isWaiting;
     $: placeholderText =

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -395,7 +395,7 @@
     $: showClearIcon =
         showSelectedItem && isClearable && !isDisabled && !isWaiting;
     $: placeholderText =
-        placeholderAlwaysShow && isMulti
+        placeholderAlwaysShow || isMulti
             ? placeholder
             : value
             ? ''


### PR DESCRIPTION
Currently, the Placeholder can only be set to always show with MultiSelection **AND** `placeholderAlwaysShow=true`.

In the `README` it states:

> `placeholderAlwaysShow: Boolean` Default: `false`. When `isMulti` then placeholder text will always still show.

I understand this as the placeholder will always show when `isMuli=true`. Additionally if `isMulti=false` it will also always show if `placeholderAlwaysShow=true`.

To fix this in <https://github.com/rob-balfre/svelte-select/blob/7e01a5ac3592ff5a1b7ef0a4f45b204337481d72/src/Select.svelte#L397-L402> the second line should be changed to `placeholderAlwaysShow || isMulti` instead IMO.
