### PR TITLE
Added `--clearSelectLeft`

### DIFF
--- a/docs/theming_variables.md
+++ b/docs/theming_variables.md
@@ -13,6 +13,7 @@ You can override the following variables to style a Select component.
 - `--clearSelectFocusColor`
 - `--clearSelectHoverColor`
 - `--clearSelectRight`
+- `--clearSelectLeft`
 - `--clearSelectTop`
 - `--clearSelectWidth`
 - `--disabledBackground`

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -751,6 +751,7 @@
     .clearSelect {
         position: absolute;
         right: var(--clearSelectRight, 10px);
+        right: var(--clearSelectLeft, auto);
         top: var(--clearSelectTop, 11px);
         bottom: var(--clearSelectBottom, 11px);
         width: var(--clearSelectWidth, 20px);


### PR DESCRIPTION
I added this because I need it. I'm working on an RTL website and I need the clear icon to be on the left side. This is the workaround:
```CSS
/* _, icon width, spacing */
--clearSelectRight: calc(100% - 20px - 16px);
```

After this PR:
```CSS
--clearSelectLeft: 16px;
--clearSelectRight: unset;
```

THANKS FOR CREATING THIS COMPONENT❤️