### PR TITLE
Feature/customize create label

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ yarn add svelte-select
 - `filterText: String` Default: `''`. Text to filter `items` by.
 - `placeholder: String` Default: `'Select...'`. Placeholder text.
 - `noOptionsMessage: String` Default: `'No options'`. Message to display in list when there are no `items`.
+- `createMessage: String` Default: `'Create '`. Message to display before the new element when creating a new value (use alongside `isCreatable`).
 - `optionIdentifier: String` Default: `'value'`. Override default identifier.
 - `labelIdentifier: String` Default: `'label'`. Override default identifier.
 - `listOpen: Boolean` Default: `false`. Open/close list.

--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -35,7 +35,7 @@
     export let labelIdentifier = 'label';
     export let getOptionLabel = (option, filterText) => {
         return option.isCreator
-            ? `Create \"${filterText}\"`
+            ? `${createMessage}\"${filterText}\"`
             : option[labelIdentifier];
     };
     export let optionIdentifier = 'value';
@@ -74,6 +74,7 @@
     export let isVirtualList = false;
     export let loadOptionsInterval = 300;
     export let noOptionsMessage = 'No options';
+    export let createMessage = "Create ";
     export let hideEmptyState = false;
     export let inputAttributes = {};
     export let listAutoWidth = true;


### PR DESCRIPTION
Here is a tiny PR to allow creation label customization (since it's in English by default).

I voluntarily add the leading space in the exported props since the rules of spacing may vary from language to language. For example, there is no space before a colon in English but there is in French...

If you want me to make any change, let me know.

Also, it seems that you have a lot to maintain in here. If you'd like a little help, I'd be glad to help! ;)