### PR TITLE
add ClearIcon to index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,7 @@ export interface SelectProps {
   Item?: any;
   Selection?: any;
   MultiSelection?: any;
+  ClearIcon?: any;
   isMulti?: boolean;
   isDisabled?: boolean;
   isCreatable?: boolean;


### PR DESCRIPTION
So why don't we use `SvelteComponent` but use `any`?