### PR TITLE
Feature: force list to stay open for debugging

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -106,7 +106,7 @@
      * for debug purpose only
      * @type {boolean}
      */
-    export let DebugkeepListOpen = false;
+    export let DebugKeepListOpen = false;
 
     export { containerClasses as class };
 
@@ -253,7 +253,7 @@
     $: if (!value && isMulti && prev_value) dispatch('change', value);
     $: if (isFocused !== prev_isFocused) setupFocus();
     $: if (filterText !== prev_filterText) setupFilterText();
-    $: if (DebugkeepListOpen === true && listOpen === false) listOpen = true;
+    $: if (DebugKeepListOpen === true && listOpen === false) listOpen = true;
 
     function setupFilterText() {
         if (filterText.length === 0) return;

--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -102,6 +102,12 @@
     export let listOffset = 5;
     export let suggestions = null;
 
+    /**
+     * for debug purpose only
+     * @type {boolean}
+     */
+    export let DebugkeepListOpen = false;
+
     export { containerClasses as class };
 
     function addCreatableItem(_items, _filterText) {
@@ -247,6 +253,7 @@
     $: if (!value && isMulti && prev_value) dispatch('change', value);
     $: if (isFocused !== prev_isFocused) setupFocus();
     $: if (filterText !== prev_filterText) setupFilterText();
+    $: if (DebugkeepListOpen === true && listOpen === false) listOpen = true;
 
     function setupFilterText() {
         if (filterText.length === 0) return;


### PR DESCRIPTION
Just a small change for debug purposes. With the new flag DebugKeepListOpen it is possible to force the list to stay open.
This can be usefull for inspecting the list and do some CSS-work.