### PR TITLE
fix filtering when groupFilter exists

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -281,7 +281,7 @@
         const sortedGroupedItems = [];
 
         groupFilter(groupValues).forEach((groupValue) => {
-            sortedGroupedItems.push(...groups[groupValue]);
+            if (groups[groupValue]) sortedGroupedItems.push(...groups[groupValue]);
         });
 
         return sortedGroupedItems;


### PR DESCRIPTION
this fixes an issue where, when a filter text is entered and a group becomes empty, it crashes  with a `TypeError: groups[groupValue] is not iterable (cannot read property undefined)`

example:
```svelte
<script>
interface Country {
  code: string;
  name: string;
}
let countries: Country[]; // = ... irrelevant;
</script>

<Select
  on:select={(e) => changeCountry(e.detail.code)}
  value={countries?.find((c) => c.code === address.country)}
  items={countries}
  groupBy={(c) => (["DE", "AT", "CH"].includes(c.code) ? "DACH" : "")}
  groupFilter={() => ["DACH", ""]}
  optionIdentifier="code"
  labelIdentifier="name"
  isClearable={false}
  placeholder="Land"
  showIndicator={true}
/>
```