### PR TITLE
Fix search input not filling entire select component, not centered

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -910,6 +910,11 @@
         background: transparent;
         font-size: var(--font-size);
     }
+    
+    :not(.multi) > .value-container > input {
+        width: 100%;
+        height: 100%;
+    }
 
     input::placeholder {
         color: var(--placeholder-color, #78848f);


### PR DESCRIPTION
Setting the width and height of the input to 100% seems to do the trick :)