### PR TITLE
Fix null error when using loadOptions and value

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -84,7 +84,7 @@
 
     function setValue() {
         if (typeof value === 'string') {
-            let item = items.find((item) => item[itemId] === value);
+            let item = (items || []).find((item) => item[itemId] === value);
             value = item || {
                 [itemId]: value,
                 label: value,

--- a/test/src/LoadOptionsGroup.svelte
+++ b/test/src/LoadOptionsGroup.svelte
@@ -10,6 +10,7 @@
     ];
 
     export let filterText;
+    export let value = undefined;
 
     async function loadOptions() {
         return items.filter((i) => i.label.toLowerCase().includes(filterText.toLowerCase()));
@@ -18,4 +19,4 @@
     const groupBy = (i) => i.group;
 </script>
 
-<Select {loadOptions} bind:filterText {groupBy} />
+<Select {loadOptions} bind:filterText {groupBy} {value} />

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -3599,3 +3599,17 @@ test('when loadOptions and groupBy then titles should not duplicate after filter
   select.$destroy();
 });
 
+test('when loadOptions and value then it should set initial value', async (t) => {
+  const select = new LoadOptionsGroup({
+    target,
+    props: {
+      value: 'cake'
+    }
+  });
+
+  t.ok(document.querySelector('.value-container .selected-item').innerHTML === 'cake');
+  await wait(500);
+  t.ok(document.querySelector('.value-container .selected-item').innerHTML === 'Cake');
+
+  select.$destroy();
+});


### PR DESCRIPTION
This PR fixes an error that occurs when using a string `value` together with `loadOptions`.

Since the initial items list is empty by default, giving a non-empty `value` prop to the `Select` component resulted in the error `TypeError: Cannot read properties of null (reading 'find')`