### PR TITLE
[Fix] list-item default marker styling

### DIFF
--- a/src/lib/tailwind.css
+++ b/src/lib/tailwind.css
@@ -124,3 +124,7 @@
 .multi-item-clear {
     @apply flex items-center justify-center w-5;
 }
+
+.list-item {
+    @apply list-none;
+}


### PR DESCRIPTION
Safari auomatically puts a marker on elements styled with `display: list-item`. Other browsers do not do this. This CSS explicitly removes that styling.