### PR TITLE
set clear button to type="button"

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -802,7 +802,8 @@
                 class="icon clear-select"
                 on:click|preventDefault|stopPropagation={handleClear}
                 on:pointerdown|preventDefault|stopPropagation
-                tabindex="0">
+                tabindex="0"
+                type="button">
                 <slot name="clear-icon">
                     <ClearIcon />
                 </slot>


### PR DESCRIPTION
otherwise, when having a value selected and hitting enter in any input which is part of the same `form` will clear svelte-select