### PR TITLE
Fix select for touch event on indicator icons

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -679,6 +679,7 @@
     class:error={hasError}
     style={containerStyles}
     on:pointerup|preventDefault={handleClick}
+    on:mousedown|preventDefault
     bind:this={container}
     use:floatingRef>
     {#if listOpen}


### PR DESCRIPTION
This PR fixes the touch event on divs/containers that inside the `svelte-select` class div but outside the select `<input />`, such as the chevron and prepend icons.

Repro:
Click the chevron icon with a touchscreen:
https://svelte-select-examples.vercel.app/examples/props/show-chevron

I've tested this on Chrome/Firefox/Edge Android.
This can also be easily tested on desktop with Firefox's Responsive Design Mode with Touch Simulation Enabled, as shown here:
https://user-images.githubusercontent.com/4538842/215847101-29f38b15-5f80-4029-b4da-9e223ff0f56e.mp4

Touching the icon results in opening the list, and then immediately closing it. On desktop with a mouse, the list opens twice.

Same behavior when clicking the `prepend` icon:
https://svelte-select-examples.vercel.app/examples/slots/prepend

This is because both the `mousedown` and `pointerup` events are fired.
Adding `preventDefault` `mousedown` fixes it.

Addition to: https://github.com/rob-balfre/svelte-select/issues/403
And may fix: https://github.com/rob-balfre/svelte-select/issues/324

P.S: Thank you for creating/maintaining this library! Amazing :raised_hands: 