### PR TITLE
Fix typo in theming variables doc

### DIFF
--- a/docs/theming_variables.md
+++ b/docs/theming_variables.md
@@ -8,7 +8,7 @@ Override the following CSS custom properties (variables) to style svelte-select 
 - `--border-focused`
 - `--border-hover`
 - `--border-radius`
-- `--border-radius-focused`git
+- `--border-radius-focused`
 - `--box-sizing`
 - `--chevron-background`
 - `--chevron-border`


### PR DESCRIPTION
Thanks for merging #542, I've accidentally made a typo in the docs file, here is the fix
