### PR TITLE
fix: border-radius is overwritten on top-level component

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -892,10 +892,9 @@
         --spinnerWidth: var(--spinner-width);
 
         --internal-padding: 0 0 0 16px;
-        --border-radius: 6px;
 
         border: var(--border, 1px solid #d8dbdf);
-        border-radius: var(--border-radius);
+        border-radius: var(--border-radius, 6px);
         min-height: var(--height, 42px);
         position: relative;
         display: flex;


### PR DESCRIPTION
It seems that our yesterday changes have broken the original --border-radius property, because it's now overridden on the top-level despite being set.
So it's incorrect to set the default value like this and we should only use fallback parameter in var(..) function.
