### PR TITLE
`list-prepend` and `list-append` slots

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -694,6 +694,7 @@
             on:scroll={handleListScroll}
             on:pointerdown|preventDefault={handlePointerDown}
             on:pointerup|preventDefault|stopPropagation>
+            <slot name='list-prepend'/>
             {#if $$slots.list}<slot name="list" {filteredItems} />
             {:else if filteredItems.length > 0}
                 {#each filteredItems as item, i}
@@ -725,6 +726,7 @@
                     <div class="empty">No options</div>
                 </slot>
             {/if}
+            <slot name='list-append'/>
         </div>
     {/if}
 


### PR DESCRIPTION
Closes https://github.com/rob-balfre/svelte-select/issues/564. Adds a slot to append content before and after the dropdown list. This preserves the original logic of the list, saving developers (me) from having to copy all of the wonderful default code. This prevents users from having to default to using the list slot to prepend or append any additional content to the list, such as buttons or links.