### PR TITLE
fix: #610 resolve ARIA warnings by defining a role on interactive divs

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -678,7 +678,8 @@
     on:pointerup|preventDefault={handleClick}
     on:mousedown|preventDefault
     bind:this={container}
-    use:floatingRef>
+    use:floatingRef
+    role="none">
     {#if listOpen}
         <div
             use:floatingContent
@@ -697,7 +698,8 @@
                         on:click|stopPropagation={() => handleItemClick({ item, i })}
                         on:keydown|preventDefault|stopPropagation
                         class="list-item"
-                        tabindex="-1">
+                        tabindex="-1"
+                        role="none">
                         <div
                             use:activeScroll={{ scroll: isItemActive(item, value, itemId), listDom }}
                             use:hoverScroll={{ scroll: scrollToHoverItem === i, listDom }}
@@ -745,7 +747,8 @@
                         class:active={activeValue === i}
                         class:disabled
                         on:click|preventDefault={() => (multiFullItemClearable ? handleMultiItemClear(i) : {})}
-                        on:keydown|preventDefault|stopPropagation>
+                        on:keydown|preventDefault|stopPropagation
+                        role="none">
                         <span class="multi-item-text">
                             <slot name="selection" selection={item} index={i}>
                                 {item[label]}


### PR DESCRIPTION
This PR fixes #610. 

It adds a `role="none"` to the three interactive divs, resolving the warnings given by Svelte 4 (tested it by importing `svelte-select` in a project with Svelte 4). 

I've had a look through the list with available [ARIA roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques) but I didn't find meaning rules matching the three cases in this PR, therefore I choose `role="none"`.