### PR TITLE
implement drag-to-reorder behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ List position and floating is powered by `floating-ui`, see their [package-entry
 | containerStyles        | `string`  | `''`            | Add inline styles to container                                 |
 | clearable              | `boolean` | `true`          | Enable clearing of value(s)                                    |
 | disabled               | `boolean` | `false`         | Disable select                                                 |
+| dragToReorder          | `boolean` | `false`         | Allow selected items to be re-ordered with drag-and-drop       |
 | multiple               | `boolean` | `false`         | Enable multi-select                                            |
 | searchable             | `boolean` | `true`          | If `false` search/filtering is disabled                        |
 | groupHeaderSelectable  | `boolean` | `false`         | Enable selectable group headers                                |

--- a/src/routes/examples/props/dragToReorder/+page.svelte
+++ b/src/routes/examples/props/dragToReorder/+page.svelte
@@ -1,0 +1,21 @@
+<script>
+    import Select from '$lib/Select.svelte';
+
+    let items = [
+        { value: 'one', label: 'One' },
+        { value: 'two', label: 'Two' },
+        { value: 'three', label: 'Three' },
+        { value: 'four', label: 'Four' },
+        { value: 'five', label: 'Five' },
+        { value: 'six', label: 'Six' },
+    ];
+
+    let value = [
+        { value: 'one', label: 'One' },
+        { value: 'two', label: 'Two' },
+        { value: 'three', label: 'Three' },
+    ];
+</script>
+
+<Select {items} multiple dragToReorder bind:value/>
+


### PR DESCRIPTION
If multiple values have been selected, then this allows the items to be re-ordered: dragging one item onto another moves the first item to be immediately before/after the second (depending on whether it was initially before or after the second item).