### PR TITLE
Fix input focus issue in Select component

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -454,7 +454,7 @@
     function handleFocus(e) {
         if (focused && input === document?.activeElement) return;
         if (e) dispatch('focus', e);
-        input.focus();
+        input?.focus();
         focused = true;
     }
 
@@ -465,7 +465,7 @@
             closeList();
             focused = false;
             activeValue = undefined;
-            input.blur();
+            input?.blur();
         }
     }
 


### PR DESCRIPTION
Fixes a crash when trying to read a property of an undefined value.

```
Select.svelte:457 Uncaught TypeError: Cannot read properties of undefined (reading 'focus')
    at HTMLInputElement.handleFocus (Select.svelte:457:15)
    at onScanElements (focusTrap.js:31:27)
    at focusTrap (focusTrap.js:37:5)
    at Object.mount [as m] (Modal.svelte:145:40)
    at Object.mount [as m] (Modal.svelte:137:19)
    at Object.update [as p] (Modal.svelte:136:28)
    at update (scheduler.js:119:30)
    at flush (scheduler.js:79:5)
handleFocus @ Select.svelte:457
onScanElements @ focusTrap.js:31
focusTrap @ focusTrap.js:37
mount @ Modal.svelte:145
mount @ Modal.svelte:137
update @ Modal.svelte:136
update @ scheduler.js:119
flush @ scheduler.js:79
Promise.then (async)
schedule_update @ scheduler.js:20
make_dirty @ Component.js:81
(anonymous) @ Component.js:139
(anonymous) @ Modal.svelte:46
set @ index.js:56
update @ index.js:69
trigger @ stores.js:41
(anonymous) @ +page.svelte:160
handleModal @ +page.svelte:149
click_handler_1 @ +page.svelte:417

```