### PR TITLE
fix: unknown extension .svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-svelte": "^7.1.4",
-    "svelte": "^3.58.0",
     "sirv-cli": "^2.0.2",
+    "svelte": "^3.58.0",
     "svelte-highlight": "^7.2.1",
     "svelte-preprocess": "^5.0.3",
     "svelte-tiny-virtual-list": "^2.0.5",
@@ -63,6 +63,12 @@
     }
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "svelte": "./index.js",
+      "types": "./index.d.ts"
+    }
+  },
   "dependencies": {
     "@floating-ui/dom": "^1.2.1",
     "svelte-floating-ui": "1.2.8"


### PR DESCRIPTION
closes https://github.com/rob-balfre/svelte-select/issues/645

I've tested running npm run prepare and the resulting package.json has only the exports "." property changed that fixes the issue.

the svelte package has been moved in the package.json to be in alphabetical order.

let me know if you need anything, happy to help in any way I can.

here is the reference for the spec https://kit.svelte.dev/docs/packaging#anatomy-of-a-package-json
that talks about the change I made.