### PR TITLE
Address ARIA + vite-plugin-svelte warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "5.8.1",
       "license": "ISC",
       "dependencies": {
-        "@floating-ui/dom": "^1.2.1",
-        "svelte-floating-ui": "1.2.8"
+        "svelte-floating-ui": "1.5.8"
       },
       "devDependencies": {
         "@rollup/plugin-alias": "^4.0.3",
@@ -466,17 +465,26 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.3"
+      }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
-      "integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
       "dependencies": {
-        "@floating-ui/core": "^1.2.1"
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
       }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
     },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
@@ -6766,12 +6774,12 @@
       }
     },
     "node_modules/svelte-floating-ui": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.2.8.tgz",
-      "integrity": "sha512-8Ifi5CD2Ui7FX7NjJRmutFtXjrB8T/FMNoS2H8P81t5LHK4I9G4NIs007rLWG/nRl7y+zJUXa3tWuTjYXw/O5A==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.5.8.tgz",
+      "integrity": "sha512-dVvJhZ2bT+kQDHlE4Lep8t+sgEc0XD96fXLzAi2DDI2bsaegBbClxXVNMma0C2WsG+n9GJSYx292dTvA8CYRtw==",
       "dependencies": {
-        "@floating-ui/core": "^1.1.0",
-        "@floating-ui/dom": "^1.1.0"
+        "@floating-ui/core": "^1.5.0",
+        "@floating-ui/dom": "^1.5.3"
       }
     },
     "node_modules/svelte-highlight": {
@@ -7760,17 +7768,26 @@
       "optional": true
     },
     "@floating-ui/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==",
+      "requires": {
+        "@floating-ui/utils": "^0.1.3"
+      }
     },
     "@floating-ui/dom": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
-      "integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
       "requires": {
-        "@floating-ui/core": "^1.2.1"
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
       }
+    },
+    "@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
     },
     "@iarna/toml": {
       "version": "2.2.5",
@@ -12195,12 +12212,12 @@
       "dev": true
     },
     "svelte-floating-ui": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.2.8.tgz",
-      "integrity": "sha512-8Ifi5CD2Ui7FX7NjJRmutFtXjrB8T/FMNoS2H8P81t5LHK4I9G4NIs007rLWG/nRl7y+zJUXa3tWuTjYXw/O5A==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.5.8.tgz",
+      "integrity": "sha512-dVvJhZ2bT+kQDHlE4Lep8t+sgEc0XD96fXLzAi2DDI2bsaegBbClxXVNMma0C2WsG+n9GJSYx292dTvA8CYRtw==",
       "requires": {
-        "@floating-ui/core": "^1.1.0",
-        "@floating-ui/dom": "^1.1.0"
+        "@floating-ui/core": "^1.5.0",
+        "@floating-ui/dom": "^1.5.3"
       }
     },
     "svelte-highlight": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   },
   "type": "module",
   "dependencies": {
-    "@floating-ui/dom": "^1.2.1",
-    "svelte-floating-ui": "1.2.8"
+    "svelte-floating-ui": "1.5.8"
   }
 }

--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -1,6 +1,6 @@
 <script>
     import { beforeUpdate, createEventDispatcher, onDestroy, onMount } from 'svelte';
-    import { offset, flip, shift } from '@floating-ui/dom';
+    import { offset, flip, shift } from 'svelte-floating-ui/dom';
     import { createFloatingActions } from 'svelte-floating-ui';
 
     const dispatch = createEventDispatcher();
@@ -691,7 +691,8 @@
             class:prefloat
             on:scroll={handleListScroll}
             on:pointerup|preventDefault|stopPropagation
-            on:mousedown|preventDefault|stopPropagation>
+            on:mousedown|preventDefault|stopPropagation
+			role="none">
             {#if $$slots['list-prepend']}<slot name="list-prepend" />{/if}
             {#if $$slots.list}<slot name="list" {filteredItems} />
             {:else if filteredItems.length > 0}


### PR DESCRIPTION
Attempting to address some warnings here:

- #655 -- A new accessibility warning got introduced recently. This PR temporarily fixes that by providing `role="none"` on the offending element, in line with the earlier fixes in https://github.com/rob-balfre/svelte-select/pull/624.
- #656 -- `vite-plugin-svelte` complains about certain export options, which appear here because of an older version of `svelte-floating-ui`. (I don't think this applies directly to `svelte-select`, since it doesn't have the `svelte` field in its `package.json` anymore.) Updating the version of `svelte-floating-ui` and re-running the tests appeared to all be fine.

Closes #655, #656 