### PR TITLE
Fix input outline when focused

### DIFF
--- a/src/Select.svelte
+++ b/src/Select.svelte
@@ -716,6 +716,7 @@
 
     .selectContainer input:focus {
         outline: none;
+        box-shadow: none;
     }
 
     .selectContainer:hover {


### PR DESCRIPTION
Fixes #519 

This removes the `box-shadow` that Tailwind adds to inputs by default, which eliminates the weird outline shown in #519.