### PR TITLE
Allow overriding keyboard handling

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -366,6 +366,12 @@
     function handleKeyDown(e) {
         if (!focused) return;
         e.stopPropagation();
+
+        // allow users to override our handler
+        if (!dispatch("keydown", e, { cancelable: true })) {
+          return;
+        }
+
         switch (e.key) {
             case 'Escape':
                 e.preventDefault();


### PR DESCRIPTION
This allows users to bring their own handler `<Select on:keydown={myKeyDownHandler} />`.

I use it to reset internal state of a complex search bar on top of svelte-select when hitting ESC