### PR TITLE
Prevent directory import error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.8.3",
       "license": "ISC",
       "dependencies": {
-        "svelte-floating-ui": "1.5.8"
+        "svelte-floating-ui": "1.5.9"
       },
       "devDependencies": {
         "@rollup/plugin-alias": "^4.0.3",
@@ -6774,9 +6774,9 @@
       }
     },
     "node_modules/svelte-floating-ui": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.5.8.tgz",
-      "integrity": "sha512-dVvJhZ2bT+kQDHlE4Lep8t+sgEc0XD96fXLzAi2DDI2bsaegBbClxXVNMma0C2WsG+n9GJSYx292dTvA8CYRtw==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.5.9.tgz",
+      "integrity": "sha512-X5690AOuPlox+C2C4RvL6JAl/hDHEvwXXrUqWXYLN4L9ClMEZfZIfXYl8IMw6Mf7Hv9z8VjUKGsfN4IwxjDqSA==",
       "dependencies": {
         "@floating-ui/core": "^1.5.0",
         "@floating-ui/dom": "^1.5.3"
@@ -12212,9 +12212,9 @@
       "dev": true
     },
     "svelte-floating-ui": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.5.8.tgz",
-      "integrity": "sha512-dVvJhZ2bT+kQDHlE4Lep8t+sgEc0XD96fXLzAi2DDI2bsaegBbClxXVNMma0C2WsG+n9GJSYx292dTvA8CYRtw==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.5.9.tgz",
+      "integrity": "sha512-X5690AOuPlox+C2C4RvL6JAl/hDHEvwXXrUqWXYLN4L9ClMEZfZIfXYl8IMw6Mf7Hv9z8VjUKGsfN4IwxjDqSA==",
       "requires": {
         "@floating-ui/core": "^1.5.0",
         "@floating-ui/dom": "^1.5.3"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
     }
   },
   "dependencies": {
-    "svelte-floating-ui": "1.5.8"
+    "svelte-floating-ui": "1.5.9"
   }
 }


### PR DESCRIPTION
Fixes an issue with svelte-floating-ui dependency where there is an issue with directory import.
It's fixed in svelte-floating-ui v1.5.9