### PR TITLE
Do not use self-closing select tag

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -825,7 +825,7 @@
 
     {#if required && (!value || value.length === 0)}
         <slot name="required" {value}>
-            <select class="required" required tabindex="-1" aria-hidden="true" />
+            <select class="required" required tabindex="-1" aria-hidden="true"></select>
         </slot>
     {/if}
 </div>


### PR DESCRIPTION
Can we fix this for Svelte 5 usage?

```
[vite-plugin-svelte] node_modules/svelte-select@5.8.3/node_modules/svelte-select/Select.svelte:828:12 Self-closing HTML tags for non-void elements are ambiguous — use `<select ...></select>` rather than `<select ... />`
826:     {#if required && (!value || value.length === 0)}
827:         <slot name="required" {value}>
828:             <select class="required" required tabindex="-1" aria-hidden="true" />
                                                                                      ^
829:         </slot>
830:     {/if}
```
